### PR TITLE
Phase 2 MVP: SQLite audio uploads, Alembic migrations, and Streamlit library

### DIFF
--- a/apps/web/app.py
+++ b/apps/web/app.py
@@ -1,19 +1,130 @@
 import os
+from typing import Any
 
 import requests
 import streamlit as st
 
 PROJECT_NAME = "echo-mvp"
 API_BASE_URL = os.getenv("API_BASE_URL", "http://api:8000")
+ALLOWED_TYPES = ["mp3", "m4a", "mp4", "wav", "ogg"]
 
-st.set_page_config(page_title=PROJECT_NAME)
+
+st.set_page_config(page_title=PROJECT_NAME, layout="wide")
 st.title("Echo MVP (capsule de vie)")
-st.write("Squelette Streamlit prêt pour les prochaines itérations.")
-st.caption(f"API_BASE_URL: {API_BASE_URL}")
 
-try:
-    response = requests.get(f"{API_BASE_URL}/health", timeout=5)
-    response.raise_for_status()
-    st.success(f"API en ligne: {response.json()}")
-except requests.RequestException as exc:
-    st.warning(f"API indisponible: {exc}")
+if "user_id" not in st.session_state:
+    st.session_state.user_id = ""
+
+
+with st.sidebar:
+    st.header("Session")
+    st.session_state.user_id = st.text_input("user_id", value=st.session_state.user_id)
+    st.caption(f"API_BASE_URL: {API_BASE_URL}")
+
+
+def api_json_error(response: requests.Response) -> str:
+    try:
+        payload = response.json()
+        if "error" in payload:
+            return payload["error"].get("message", str(payload["error"]))
+        return str(payload)
+    except ValueError:
+        return response.text
+
+
+def check_api_health() -> None:
+    try:
+        response = requests.get(f"{API_BASE_URL}/health", timeout=5)
+        response.raise_for_status()
+        st.success("API connectée")
+    except requests.RequestException as exc:
+        st.error(f"API indisponible: {exc}")
+
+
+def fetch_today_question() -> dict[str, Any] | None:
+    try:
+        response = requests.get(f"{API_BASE_URL}/questions/today", timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        st.error(f"Impossible de charger la question: {exc}")
+        return None
+
+
+def upload_entry(user_id: str, question_id: int, uploaded_file: Any) -> None:
+    try:
+        files = {"audio_file": (uploaded_file.name, uploaded_file.getvalue(), uploaded_file.type)}
+        data = {"user_id": user_id, "question_id": str(question_id)}
+        response = requests.post(f"{API_BASE_URL}/entries", data=data, files=files, timeout=30)
+        if response.status_code >= 400:
+            st.error(f"Upload refusé: {api_json_error(response)}")
+            return
+        st.success("Entrée créée avec succès")
+    except requests.RequestException as exc:
+        st.error(f"Erreur réseau pendant l'upload: {exc}")
+
+
+def list_entries(user_id: str) -> list[dict[str, Any]]:
+    try:
+        response = requests.get(f"{API_BASE_URL}/entries", params={"user_id": user_id}, timeout=10)
+        if response.status_code >= 400:
+            st.error(f"Impossible de charger la bibliothèque: {api_json_error(response)}")
+            return []
+        return response.json()
+    except requests.RequestException as exc:
+        st.error(f"Erreur réseau: {exc}")
+        return []
+
+
+def delete_entry(entry_id: str) -> None:
+    try:
+        response = requests.delete(f"{API_BASE_URL}/entries/{entry_id}", timeout=10)
+        if response.status_code >= 400:
+            st.error(f"Suppression impossible: {api_json_error(response)}")
+            return
+        st.success("Entrée supprimée")
+    except requests.RequestException as exc:
+        st.error(f"Erreur réseau: {exc}")
+
+
+check_api_health()
+
+tab_question, tab_library = st.tabs(["Question du jour", "Bibliothèque"])
+
+with tab_question:
+    st.subheader("Répondre à la question")
+    if not st.session_state.user_id.strip():
+        st.info("Renseignez un user_id dans la barre latérale pour continuer.")
+    else:
+        question = fetch_today_question()
+        if question:
+            st.markdown(f"**{question['text']}**")
+            st.caption(f"Catégorie: {question['category']}")
+
+            uploaded = st.file_uploader(
+                "Ajoutez un audio (max 25MB)",
+                type=ALLOWED_TYPES,
+                accept_multiple_files=False,
+            )
+            if st.button("Envoyer", disabled=uploaded is None):
+                if uploaded is None:
+                    st.warning("Sélectionnez un fichier audio.")
+                else:
+                    upload_entry(st.session_state.user_id.strip(), question["id"], uploaded)
+
+with tab_library:
+    st.subheader("Mes entrées")
+    if not st.session_state.user_id.strip():
+        st.info("Renseignez un user_id pour afficher la bibliothèque.")
+    else:
+        entries = list_entries(st.session_state.user_id.strip())
+        if not entries:
+            st.write("Aucune entrée pour le moment.")
+        for entry in entries:
+            with st.container(border=True):
+                st.write(f"Entry: `{entry['id']}`")
+                st.write(f"Question ID: {entry['question_id']} · Taille: {entry['audio_size']} octets")
+                st.audio(f"{API_BASE_URL}/entries/{entry['id']}/audio", format=entry["audio_mime"])
+                if st.button("Supprimer", key=f"delete-{entry['id']}"):
+                    delete_entry(entry["id"])
+                    st.rerun()

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY pyproject.toml ./
 COPY app ./app
+COPY alembic.ini ./
+COPY alembic ./alembic
 
 RUN pip install --no-cache-dir .
 

--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:////app/data/echo.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -1,0 +1,47 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.db import Base
+from app.models import Entry, Question  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/api/alembic/script.py.mako
+++ b/services/api/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/services/api/alembic/versions/0001_init.py
+++ b/services/api/alembic/versions/0001_init.py
@@ -1,0 +1,50 @@
+"""initial schema
+
+Revision ID: 0001_init
+Revises: 
+Create Date: 2026-02-17
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_init"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "questions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("text", sa.String(), nullable=False),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_questions_id"), "questions", ["id"], unique=False)
+
+    op.create_table(
+        "entries",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("question_id", sa.Integer(), nullable=False),
+        sa.Column("audio_path", sa.String(), nullable=False),
+        sa.Column("audio_mime", sa.String(), nullable=False),
+        sa.Column("audio_size", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["question_id"], ["questions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_entries_user_id"), "entries", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_entries_user_id"), table_name="entries")
+    op.drop_table("entries")
+    op.drop_index(op.f("ix_questions_id"), table_name="questions")
+    op.drop_table("questions")

--- a/services/api/app/db.py
+++ b/services/api/app/db.py
@@ -1,0 +1,22 @@
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+from app.settings import settings
+
+Base = declarative_base()
+
+engine = create_engine(
+    f"sqlite:///{settings.data_dir / 'echo.db'}",
+    connect_args={"check_same_thread": False},
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,8 +1,71 @@
-from fastapi import FastAPI
+from datetime import date
+from pathlib import Path
+import uuid
 
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import FileResponse, JSONResponse
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import Base, engine, get_db
+from app.models import Entry, Question
+from app.schemas import EntryOut, QuestionOut
 from app.settings import settings
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
+
+ALLOWED_MIME_TYPES = {
+    "audio/mpeg": "mp3",
+    "audio/mp4": "mp4",
+    "audio/x-m4a": "m4a",
+    "audio/wav": "wav",
+    "audio/ogg": "ogg",
+}
+
+SEED_QUESTIONS: list[tuple[str, str]] = [
+    ("Quel moment t'a fait sourire aujourd'hui ?", "gratitude"),
+    ("Qu'as-tu appris de nouveau cette semaine ?", "apprentissage"),
+    ("Quelle personne t'a inspiré récemment ?", "relations"),
+    ("Quelle petite victoire veux-tu célébrer ?", "accomplissement"),
+    ("Quel souvenir veux-tu garder de cette journée ?", "memoire"),
+    ("Qu'est-ce qui t'a surpris positivement ?", "surprise"),
+    ("Quel défi as-tu surmonté récemment ?", "resilience"),
+    ("Comment prends-tu soin de toi en ce moment ?", "bien-etre"),
+    ("Quel objectif te motive pour demain ?", "projection"),
+    ("Quelle émotion as-tu le plus ressentie aujourd'hui ?", "emotion"),
+]
+
+
+@app.on_event("startup")
+def startup() -> None:
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    settings.audio_dir.mkdir(parents=True, exist_ok=True)
+    Base.metadata.create_all(bind=engine)
+
+
+@app.exception_handler(HTTPException)
+def http_exception_handler(_, exc: HTTPException) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": {"code": str(exc.status_code), "message": str(exc.detail)}},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+def validation_exception_handler(_, exc: RequestValidationError) -> JSONResponse:
+    return JSONResponse(
+        status_code=422,
+        content={"error": {"code": "422", "message": "Validation error", "details": exc.errors()}},
+    )
+
+
+@app.exception_handler(Exception)
+def generic_exception_handler(_, __: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content={"error": {"code": "500", "message": "Internal server error"}},
+    )
 
 
 @app.get("/health")
@@ -13,3 +76,105 @@ def health() -> dict[str, str]:
 @app.get("/version")
 def version() -> dict[str, str]:
     return {"name": settings.app_name, "version": settings.app_version}
+
+
+def _ensure_questions_seeded(db: Session) -> None:
+    count = db.query(Question).count()
+    if count:
+        return
+    for idx, (text, category) in enumerate(SEED_QUESTIONS, start=1):
+        db.add(Question(id=idx, text=text, category=category, is_active=True))
+    db.commit()
+
+
+@app.get("/questions/today", response_model=QuestionOut)
+def get_question_today(db: Session = Depends(get_db)) -> Question:
+    _ensure_questions_seeded(db)
+    questions = db.execute(select(Question).where(Question.is_active.is_(True)).order_by(Question.id)).scalars().all()
+    if not questions:
+        raise HTTPException(status_code=404, detail="No active question")
+    selected = questions[date.today().toordinal() % len(questions)]
+    return selected
+
+
+@app.post("/entries", response_model=EntryOut)
+async def create_entry(
+    user_id: str = Form(...),
+    question_id: int = Form(...),
+    audio_file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> Entry:
+    _ensure_questions_seeded(db)
+    question = db.get(Question, question_id)
+    if question is None:
+        raise HTTPException(status_code=404, detail="Question not found")
+
+    content_type = audio_file.content_type or ""
+    if content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(status_code=422, detail="Unsupported audio MIME type")
+
+    file_bytes = await audio_file.read()
+    if len(file_bytes) > settings.max_upload_bytes:
+        raise HTTPException(status_code=422, detail="Audio file exceeds 25 MB")
+
+    entry_id = str(uuid.uuid4())
+    ext = ALLOWED_MIME_TYPES[content_type]
+    relative_path = Path("audio") / f"{entry_id}.{ext}"
+    absolute_path = settings.data_dir / relative_path
+    absolute_path.parent.mkdir(parents=True, exist_ok=True)
+    absolute_path.write_bytes(file_bytes)
+
+    entry = Entry(
+        id=entry_id,
+        user_id=user_id,
+        question_id=question_id,
+        audio_path=str(relative_path),
+        audio_mime=content_type,
+        audio_size=len(file_bytes),
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+@app.get("/entries", response_model=list[EntryOut])
+def list_entries(user_id: str = Query(...), db: Session = Depends(get_db)) -> list[Entry]:
+    entries = (
+        db.execute(select(Entry).where(Entry.user_id == user_id).order_by(Entry.created_at.desc()))
+        .scalars()
+        .all()
+    )
+    return entries
+
+
+@app.get("/entries/{entry_id}", response_model=EntryOut)
+def get_entry(entry_id: str, db: Session = Depends(get_db)) -> Entry:
+    entry = db.get(Entry, entry_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    return entry
+
+
+@app.get("/entries/{entry_id}/audio")
+def get_entry_audio(entry_id: str, db: Session = Depends(get_db)) -> FileResponse:
+    entry = db.get(Entry, entry_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    path = settings.data_dir / entry.audio_path
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Audio file not found")
+    return FileResponse(path=path, media_type=entry.audio_mime, filename=path.name)
+
+
+@app.delete("/entries/{entry_id}")
+def delete_entry(entry_id: str, db: Session = Depends(get_db)) -> dict[str, str]:
+    entry = db.get(Entry, entry_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
+
+    path = settings.data_dir / entry.audio_path
+    db.delete(entry)
+    db.commit()
+    path.unlink(missing_ok=True)
+    return {"status": "deleted", "id": entry_id}

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class Question(Base):
+    __tablename__ = "questions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    text: Mapped[str] = mapped_column(String, nullable=False)
+    category: Mapped[str] = mapped_column(String, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+
+class Entry(Base):
+    __tablename__ = "entries"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    question_id: Mapped[int] = mapped_column(ForeignKey("questions.id"), nullable=False)
+    audio_path: Mapped[str] = mapped_column(String, nullable=False)
+    audio_mime: Mapped[str] = mapped_column(String, nullable=False)
+    audio_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class QuestionOut(BaseModel):
+    id: int
+    text: str
+    category: str
+    is_active: bool
+
+
+class EntryOut(BaseModel):
+    id: str
+    user_id: str
+    question_id: int
+    audio_mime: str
+    audio_size: int
+    created_at: datetime
+
+
+class ErrorResponse(BaseModel):
+    error: dict[str, str]

--- a/services/api/app/settings.py
+++ b/services/api/app/settings.py
@@ -8,12 +8,21 @@ class Settings(BaseSettings):
     app_version: str = "0.1.0"
     app_env: str = "development"
     data_dir: Path = Path("/app/data")
+    max_upload_size_mb: int = 25
 
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
     )
+
+    @property
+    def max_upload_bytes(self) -> int:
+        return self.max_upload_size_mb * 1024 * 1024
+
+    @property
+    def audio_dir(self) -> Path:
+        return self.data_dir / "audio"
 
 
 settings = Settings()

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -10,7 +10,16 @@ requires-python = ">=3.11"
 dependencies = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.0",
-  "pydantic-settings>=2.4.0"
+  "pydantic-settings>=2.4.0",
+  "sqlalchemy>=2.0.35",
+  "alembic>=1.13.2",
+  "python-multipart>=0.0.9"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.3.0",
+  "httpx>=0.27.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -1,0 +1,79 @@
+from io import BytesIO
+
+from fastapi.testclient import TestClient
+
+
+def _build_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import app.db
+    import app.main
+    import app.settings
+
+    app.settings.settings = app.settings.Settings()
+    app.db.settings = app.settings.settings
+    app.main.settings = app.settings.settings
+
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+
+    app.main.engine = app.db.engine
+    app.main.Base.metadata.drop_all(bind=app.db.engine)
+    app.main.Base.metadata.create_all(bind=app.db.engine)
+
+    return TestClient(app.main.app)
+
+
+def test_create_list_delete_entry(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    question = client.get("/questions/today")
+    assert question.status_code == 200
+
+    payload = {
+        "user_id": "alice",
+        "question_id": str(question.json()["id"]),
+    }
+    files = {"audio_file": ("voice.mp3", BytesIO(b"fake-audio"), "audio/mpeg")}
+
+    created = client.post("/entries", data=payload, files=files)
+    assert created.status_code == 200
+    created_body = created.json()
+
+    listed = client.get("/entries", params={"user_id": "alice"})
+    assert listed.status_code == 200
+    assert len(listed.json()) == 1
+
+    audio = client.get(f"/entries/{created_body['id']}/audio")
+    assert audio.status_code == 200
+
+    deleted = client.delete(f"/entries/{created_body['id']}")
+    assert deleted.status_code == 200
+
+    listed_again = client.get("/entries", params={"user_id": "alice"})
+    assert listed_again.status_code == 200
+    assert listed_again.json() == []
+
+
+def test_404_entry(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    response = client.get("/entries/not-found")
+    assert response.status_code == 404
+
+
+def test_mime_validation(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    question = client.get("/questions/today")
+
+    payload = {
+        "user_id": "bob",
+        "question_id": str(question.json()["id"]),
+    }
+    files = {"audio_file": ("voice.txt", BytesIO(b"not-audio"), "text/plain")}
+
+    response = client.post("/entries", data=payload, files=files)
+    assert response.status_code == 422


### PR DESCRIPTION
### Motivation
- Provide phase‑2 functionality: persistent storage (SQLite) and an audio upload/library flow without AI or real auth. 
- Support multipart audio uploads with MIME/size validation and serve stored audio files from the API. 
- Add a minimal Streamlit UI to upload, list, play and delete entries for a given `user_id` session.

### Description
- Add SQLAlchemy persistence and session wiring with `app/db.py`, models `Question` and `Entry` in `app/models.py`, and new settings (`max_upload_size_mb`, `audio_dir`) in `app/settings.py`. 
- Implement backend endpoints and consistent JSON error handlers: `GET /questions/today`, `POST /entries` (multipart upload with MIME + size checks), `GET /entries?user_id=...`, `GET /entries/{id}`, `GET /entries/{id}/audio`, and `DELETE /entries/{id}`. 
- Add Alembic configuration and an initial migration for `questions` and `entries`, and update the API `Dockerfile` to include Alembic files. 
- Update Streamlit app (`apps/web/app.py`) to manage `user_id` in session, question-of-the-day upload flow, library listing with audio playback and deletion, and add minimal pytest coverage (`services/api/tests/test_entries.py`).

### Testing
- Ran `pytest` in `services/api` which executed the minimal suite covering create/list/delete, 404 handling and MIME validation and all tests passed (3 passed). 
- Automated package test preparations (dev deps) were installed to run the test suite prior to `pytest` (installation step succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699498f89ad083309e36c96829137a9a)