### PR TITLE
Phase 2.5: mobile MIME support + Alembic-only DB initialization

### DIFF
--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -1,5 +1,7 @@
 from io import BytesIO
 
+from alembic import command
+from alembic.config import Config
 from fastapi.testclient import TestClient
 
 
@@ -20,10 +22,11 @@ def _build_client(tmp_path, monkeypatch):
         connect_args={"check_same_thread": False},
     )
     app.db.SessionLocal.configure(bind=app.db.engine)
-
     app.main.engine = app.db.engine
-    app.main.Base.metadata.drop_all(bind=app.db.engine)
-    app.main.Base.metadata.create_all(bind=app.db.engine)
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}")
+    command.upgrade(alembic_cfg, "head")
 
     return TestClient(app.main.app)
 
@@ -77,3 +80,51 @@ def test_mime_validation(tmp_path, monkeypatch):
 
     response = client.post("/entries", data=payload, files=files)
     assert response.status_code == 422
+    assert response.json() == {
+        "error": {
+            "code": "unsupported_mime",
+            "message": "Unsupported audio MIME type",
+        }
+    }
+
+
+def test_upload_accepts_audio_x_m4a(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    question_id = client.get("/questions/today").json()["id"]
+
+    response = client.post(
+        "/entries",
+        data={"user_id": "eve", "question_id": str(question_id)},
+        files={"audio_file": ("voice.m4a", BytesIO(b"m4a"), "audio/x-m4a")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audio_mime"] == "audio/x-m4a"
+
+
+def test_upload_accepts_audio_webm(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    question_id = client.get("/questions/today").json()["id"]
+
+    response = client.post(
+        "/entries",
+        data={"user_id": "eve", "question_id": str(question_id)},
+        files={"audio_file": ("voice.webm", BytesIO(b"webm"), "audio/webm")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audio_mime"] == "audio/webm"
+
+
+def test_upload_accepts_audio_3gpp(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    question_id = client.get("/questions/today").json()["id"]
+
+    response = client.post(
+        "/entries",
+        data={"user_id": "eve", "question_id": str(question_id)},
+        files={"audio_file": ("voice.3gp", BytesIO(b"3gpp"), "audio/3gpp")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audio_mime"] == "audio/3gpp"


### PR DESCRIPTION
### Motivation
- Extend audio upload compatibility for iOS/Android mobile formats and ensure server maps MIME types to correct file extensions.
- Remove automatic schema creation so Alembic is the only mechanism managing the DB schema and surface a clear startup warning when the DB is not initialized.
- Keep existing behavior (in-memory size validation), provide consistent JSON error payloads, and add tests for the new formats.

### Description
- Updated `services/api/app/main.py` to add extended MIME whitelist and explicit MIME→extension mapping and to store files under `data/audio/{uuid}{extension}` using the mapping via `ALLOWED_MIME_TYPES`.
- Replaced `Base.metadata.create_all()` at startup with a presence check using `inspect(engine).has_table("entries")` that logs: `Database not initialized. Run: alembic upgrade head` if missing.
- Changed unsupported MIME handling to return `422` with structured JSON `{ "error": { "code": "unsupported_mime", "message": "Unsupported audio MIME type" } }` and changed oversize response to HTTP `413` while still reading the upload into memory to check size.
- Modified tests in `services/api/tests/test_entries.py` to initialize the test DB via Alembic (`alembic.command.upgrade`) instead of using `create_all`, added tests for `audio/x-m4a`, `audio/webm`, and `audio/3gpp`, and added an assertion for the exact unsupported MIME JSON response.
- Files modified: `services/api/app/main.py`, `services/api/tests/test_entries.py`.
- New supported MIME types: `audio/mpeg`, `audio/mp4`, `audio/x-m4a`, `audio/wav`, `audio/x-wav`, `audio/ogg`, `audio/aac`, `audio/3gpp`, `audio/3gpp2`, `audio/webm`, `audio/aiff`.

### Testing
- Ran development dependency install with `pip install -q -e .[dev]` in `services/api` and then ran `pytest -q` in `services/api`, which passed (`6 passed`).
- Automated tests executed: `pytest -q` (services/api) — all tests passed.
- Manual test commands recommended: run `pytest` locally and `docker compose up --build` to validate Docker behavior and that uploads appear under `./data/audio` on the host.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949e8c2ac883309be397565f630782)