### PR TITLE
Fix Alembic DB URL resolution for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ La base SQLite est stockée dans `data/echo.db` (monté dans `/app/data` côté 
 Commandes de migration (depuis `services/api`) :
 
 ```bash
+DATA_DIR=<repo>/data alembic upgrade head
 alembic upgrade head
 alembic downgrade -1
 ```
+
+En local, définir `DATA_DIR` garantit que les migrations visent la même base que l'application.
 
 > L'application crée aussi les tables au démarrage pour éviter un écran vide en local, mais le flux recommandé reste Alembic.
 

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -1,4 +1,6 @@
+import os
 from logging.config import fileConfig
+from pathlib import Path
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
@@ -7,6 +9,12 @@ from app.db import Base
 from app.models import Entry, Question  # noqa: F401
 
 config = context.config
+
+repo_root = Path(__file__).resolve().parents[2]
+data_dir = Path(os.getenv("DATA_DIR") or (repo_root / "data"))
+data_dir.mkdir(parents=True, exist_ok=True)
+db_url = f"sqlite:///{(data_dir / 'echo.db').as_posix()}"
+config.set_main_option("sqlalchemy.url", db_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)


### PR DESCRIPTION
### Motivation

- Alembic was using the hardcoded `sqlite:////app/data/echo.db` (Docker path) from `alembic.ini`, so running `alembic upgrade head` on local/Windows targeted the wrong DB and diverged from the app which reads `DATA_DIR`.

### Description

- Updated `services/api/alembic/env.py` to compute `repo_root = Path(__file__).resolve().parents[2]` and derive `data_dir = Path(os.getenv("DATA_DIR") or (repo_root / "data"))` so migrations target the same folder as the app.
- The code now ensures the directory exists with `data_dir.mkdir(parents=True, exist_ok=True)`, builds `db_url = f"sqlite:///{(data_dir / 'echo.db').as_posix()}"`, and calls `config.set_main_option("sqlalchemy.url", db_url)` before engine creation.
- Added README guidance showing `DATA_DIR=<repo>/data alembic upgrade head` to document local usage; Docker usage remains unchanged since `DATA_DIR=/app/data` in compose will override.

### Testing

- Ran `PYTHONPATH=. DATA_DIR=/workspace/echo/data alembic upgrade head` from `services/api` and migrations applied successfully (created `./data/echo.db`).
- Started the API with `PYTHONPATH=. DATA_DIR=/workspace/echo/data python -m uvicorn app.main:app` and verified `GET /questions/today` returned HTTP `200` with the expected JSON payload.
- Ran `PYTHONPATH=. DATA_DIR=/workspace/echo/data pytest -q` but test collection failed in this environment due to a missing optional dependency (`httpx`) required by `starlette.testclient` (not a regression from these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d30e48f8833081e75ea0566cafae)