### PR TITLE
Streamlit: inclure extension audio dans le nom de fichier de téléchargement

### DIFF
--- a/apps/web/app.py
+++ b/apps/web/app.py
@@ -7,6 +7,16 @@ import streamlit as st
 PROJECT_NAME = "echo-mvp"
 API_BASE_URL = os.getenv("API_BASE_URL", "http://api:8000")
 ALLOWED_TYPES = ["mp3", "m4a", "mp4", "wav", "ogg"]
+MIME_TO_EXT = {
+    "audio/mpeg": "mp3",
+    "audio/mp4": "m4a",
+    "audio/x-m4a": "m4a",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/ogg": "ogg",
+    "audio/webm": "webm",
+    "audio/3gpp": "3gp",
+}
 
 
 st.set_page_config(page_title=PROJECT_NAME, layout="wide")
@@ -84,6 +94,14 @@ def fetch_audio_bytes(entry_id: str) -> bytes:
     return response.content
 
 
+def download_filename(entry: dict[str, Any]) -> str:
+    mime = (entry.get("audio_mime") or "").lower()
+    ext = MIME_TO_EXT.get(mime)
+    if ext:
+        return f"entry-{entry['id']}.{ext}"
+    return f"entry-{entry['id']}"
+
+
 def delete_entry(entry_id: str) -> None:
     try:
         response = requests.delete(f"{API_BASE_URL}/entries/{entry_id}", timeout=10)
@@ -143,7 +161,7 @@ with tab_library:
                         st.download_button(
                             "Télécharger",
                             data=audio_bytes,
-                            file_name=f"entry-{entry['id']}",
+                            file_name=download_filename(entry),
                             mime=entry["audio_mime"],
                             key=f"download-{entry['id']}",
                         )


### PR DESCRIPTION
### Motivation
- Le bouton Streamlit `st.download_button` utilisait `file_name` sans extension, ce qui produit des fichiers téléchargés sans suffixe; il faut une extension cohérente basée sur `entry["audio_mime"]`.
- Ne pas modifier l’API FastAPI et appliquer un patch minimal côté Streamlit pour corriger uniquement le nom de fichier.

### Description
- Ajout de la table `MIME_TO_EXT` pour mapper les MIME audio connus vers des extensions (`mp3`, `m4a`, `wav`, `ogg`, `webm`, `3gp`).
- Ajout du helper `download_filename(entry: dict[str, Any]) -> str` qui lit `entry.get("audio_mime")`, normalise en lowercase et retourne `entry-<id>.<ext>` quand le MIME est reconnu, sinon `entry-<id>`.
- Remplacement ciblé de `file_name=f"entry-{entry['id']}"` par `file_name=download_filename(entry)` dans l’appel à `st.download_button`.
- Aucun autre comportement ni API modifié; patch minimal appliqué dans `apps/web/app.py`.

### Testing
- Exécution de la compilation Python avec `python -m py_compile apps/web/app.py` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e21e80248330b164272a1c9ef516)