### PR TITLE
Finalize /api/v1 docs and extend tests to cover legacy root 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker compose exec api alembic current
 API:
 
 ```powershell
-curl http://localhost:8000/health
+curl http://localhost:8000/api/v1/health
 ```
 
 Web:
@@ -146,7 +146,7 @@ docker compose up --build
 ```
 
 Puis ouvrir:
-- API: http://localhost:8000/health
+- API: http://localhost:8000/api/v1/health
 - Web: http://localhost:8501
 
 ## Base SQLite + migrations
@@ -178,13 +178,13 @@ alembic downgrade -1
 
 1. Dans Streamlit, saisir un `user_id` (auth simplifiée de phase 2).
 2. Onglet **Question du jour**:
-   - récupère `GET /questions/today`
-   - upload audio (multipart) via `POST /entries`
+   - récupère `GET /api/v1/questions/today`
+   - upload audio (multipart) via `POST /api/v1/entries`
 3. Onglet **Bibliothèque**:
-   - liste `GET /entries?user_id=...`
-   - lecture audio via `GET /entries/{id}/audio` (en Docker, Streamlit récupère les bytes côté serveur/proxy au clic **▶ Lire**)
+   - liste `GET /api/v1/entries?user_id=...`
+   - lecture audio via `GET /api/v1/entries/{id}/audio` (en Docker, Streamlit récupère les bytes côté serveur/proxy au clic **▶ Lire**)
    - bouton **Télécharger** avec un nom de fichier incluant une extension cohérente avec `audio_mime`
-   - suppression via `DELETE /entries/{id}`
+   - suppression via `DELETE /api/v1/entries/{id}`
 
 ## Contraintes upload
 
@@ -196,18 +196,18 @@ alembic downgrade -1
   - `audio/wav`
   - `audio/ogg`
 - Stockage fichier: `data/audio/{entry_id}.{ext}` avec `entry_id` UUID
-- `DELETE /entries/{id}` supprime la ligne DB + le fichier audio
+- `DELETE /api/v1/entries/{id}` supprime la ligne DB + le fichier audio
 
 ## Endpoints API
 
-- `GET /health`
-- `GET /version`
-- `GET /questions/today`
-- `POST /entries` (multipart: `user_id`, `question_id`, `audio_file`)
-- `GET /entries?user_id=...`
-- `GET /entries/{id}`
-- `GET /entries/{id}/audio`
-- `DELETE /entries/{id}`
+- `GET /api/v1/health`
+- `GET /api/v1/version`
+- `GET /api/v1/questions/today`
+- `POST /api/v1/entries` (multipart: `user_id`, `question_id`, `audio_file`)
+- `GET /api/v1/entries?user_id=...`
+- `GET /api/v1/entries/{id}`
+- `GET /api/v1/entries/{id}/audio`
+- `DELETE /api/v1/entries/{id}`
 
 Erreurs JSON harmonisées pour validation et erreurs métier (`422`, `404`, `500`).
 

--- a/apps/web/app.py
+++ b/apps/web/app.py
@@ -5,7 +5,8 @@ import requests
 import streamlit as st
 
 PROJECT_NAME = "echo-mvp"
-API_BASE_URL = os.getenv("API_BASE_URL", "http://api:8000")
+API_BASE_URL = os.getenv("API_BASE_URL", "http://api:8000").rstrip("/")
+API_BASE_PATH = "/api/v1"
 ALLOWED_TYPES = ["mp3", "m4a", "mp4", "wav", "ogg"]
 MIME_TO_EXT = {
     "audio/mpeg": "mp3",
@@ -44,7 +45,7 @@ def api_json_error(response: requests.Response) -> str:
 
 def check_api_health() -> None:
     try:
-        response = requests.get(f"{API_BASE_URL}/health", timeout=5)
+        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/health", timeout=5)
         response.raise_for_status()
         st.success("API connectée")
     except requests.RequestException as exc:
@@ -53,7 +54,7 @@ def check_api_health() -> None:
 
 def fetch_today_question() -> dict[str, Any] | None:
     try:
-        response = requests.get(f"{API_BASE_URL}/questions/today", timeout=10)
+        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/questions/today", timeout=10)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:
@@ -65,7 +66,7 @@ def upload_entry(user_id: str, question_id: int, uploaded_file: Any) -> None:
     try:
         files = {"audio_file": (uploaded_file.name, uploaded_file.getvalue(), uploaded_file.type)}
         data = {"user_id": user_id, "question_id": str(question_id)}
-        response = requests.post(f"{API_BASE_URL}/entries", data=data, files=files, timeout=30)
+        response = requests.post(f"{API_BASE_URL}{API_BASE_PATH}/entries", data=data, files=files, timeout=30)
         if response.status_code >= 400:
             st.error(f"Upload refusé: {api_json_error(response)}")
             return
@@ -76,7 +77,7 @@ def upload_entry(user_id: str, question_id: int, uploaded_file: Any) -> None:
 
 def list_entries(user_id: str) -> list[dict[str, Any]]:
     try:
-        response = requests.get(f"{API_BASE_URL}/entries", params={"user_id": user_id}, timeout=10)
+        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/entries", params={"user_id": user_id}, timeout=10)
         if response.status_code >= 400:
             st.error(f"Impossible de charger la bibliothèque: {api_json_error(response)}")
             return []
@@ -88,7 +89,7 @@ def list_entries(user_id: str) -> list[dict[str, Any]]:
 
 @st.cache_data(show_spinner=False, max_entries=128)
 def fetch_audio_bytes(entry_id: str) -> bytes:
-    response = requests.get(f"{API_BASE_URL}/entries/{entry_id}/audio", timeout=30)
+    response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}/audio", timeout=30)
     if response.status_code >= 400:
         raise RuntimeError(api_json_error(response))
     return response.content
@@ -104,7 +105,7 @@ def download_filename(entry: dict[str, Any]) -> str:
 
 def delete_entry(entry_id: str) -> None:
     try:
-        response = requests.delete(f"{API_BASE_URL}/entries/{entry_id}", timeout=10)
+        response = requests.delete(f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}", timeout=10)
         if response.status_code >= 400:
             st.error(f"Suppression impossible: {api_json_error(response)}")
             return

--- a/docs/phase1-report.md
+++ b/docs/phase1-report.md
@@ -44,9 +44,9 @@
 - `README.md` : décrit le MVP, les prérequis, le démarrage Docker, les variables d'environnement, la structure projet, les commandes `make`, et ce qui est inclus/exclu en phase 1.
 - `docker-compose.yml` : définit 2 services (`api`, `web`), ports exposés (`8000`, `8501`), variables d'environnement, montage `./data:/app/data`, et dépendance `web -> api`.
 - `.env.example` : valeurs par défaut pour `APP_ENV`, `DATA_DIR`, et `API_BASE_URL`.
-- `services/api/app/main.py` : FastAPI minimal avec endpoints `GET /health` (`{"status":"ok"}`) et `GET /version` (`name`, `version`).
+- `services/api/app/main.py` : FastAPI minimal avec endpoints `GET /api/v1/health` (`{"status":"ok"}`) et `GET /api/v1/version` (`name`, `version`).
 - `services/api/app/settings.py` : configuration via `pydantic-settings` (`app_name`, `app_version`, `app_env`, `data_dir`) avec lecture `.env`.
-- `apps/web/app.py` : app Streamlit qui affiche le projet et teste l'API via `requests.get({API_BASE_URL}/health)` avec message succès/avertissement.
+- `apps/web/app.py` : app Streamlit qui affiche le projet et teste l'API via `requests.get({API_BASE_URL}/api/v1/health)` avec message succès/avertissement.
 - `docs/product.md` : vision produit MVP “capsule de vie”, stockage local, progression par itérations, robustesse du socle.
 - `docs/privacy.md` : principes de confidentialité (local-first, consentement, suppression utilisateur, sensibilité des audios).
 
@@ -64,8 +64,8 @@ Exécution locale des 2 apps Python :
 - API lancée avec Uvicorn sur `:8000`
 - Web Streamlit lancé sur `:8501` avec `API_BASE_URL=http://127.0.0.1:8000`
 - Checks validés :
-  - `GET /health` retourne `{"status":"ok"}`
-  - `GET /version` retourne `{"name":"echo-mvp","version":"0.1.0"}`
+  - `GET /api/v1/health` retourne `{"status":"ok"}`
+  - `GET /api/v1/version` retourne `{"name":"echo-mvp","version":"0.1.0"}`
   - L'interface Streamlit affiche bien: `API en ligne: {'status': 'ok'}`
 
 Aucune correction de code n'a été nécessaire.
@@ -104,7 +104,7 @@ docker compose up --build
 - [ ] Valider type MIME et taille max côté API.
 - [ ] Stocker les fichiers audio dans `data/audio` avec nommage robuste (UUID).
 - [ ] Gérer erreurs API standardisées (validation, not found, IO).
-- [ ] Ajouter tests API (health/version + CRUD + upload).
+- [ ] Ajouter tests API (/api/v1/health, /api/v1/version + CRUD + upload).
 - [ ] Mettre à jour Streamlit: formulaire upload + liste des enregistrements.
 - [ ] Afficher statut upload + erreurs utilisateur dans Streamlit.
 - [ ] Mettre à jour `README.md` (setup DB, endpoints, flux upload).

--- a/docs/phase2-report.md
+++ b/docs/phase2-report.md
@@ -43,14 +43,14 @@
   - `RequestValidationError` => code 422 avec `details`
   - exception générique => code 500 standardisé
 - Routes:
-  - `GET /health`
-  - `GET /version`
-  - `GET /questions/today` (seed auto + rotation déterministe via date)
-  - `POST /entries` (multipart `user_id`, `question_id`, `audio_file`; validation MIME + taille; écriture disque + insertion DB)
-  - `GET /entries?user_id=...`
-  - `GET /entries/{entry_id}`
-  - `GET /entries/{entry_id}/audio` (retourne `FileResponse`)
-  - `DELETE /entries/{entry_id}` (supprime DB puis fichier)
+  - `GET /api/v1/health`
+  - `GET /api/v1/version`
+  - `GET /api/v1/questions/today` (seed auto + rotation déterministe via date)
+  - `POST /api/v1/entries` (multipart `user_id`, `question_id`, `audio_file`; validation MIME + taille; écriture disque + insertion DB)
+  - `GET /api/v1/entries?user_id=...`
+  - `GET /api/v1/entries/{entry_id}`
+  - `GET /api/v1/entries/{entry_id}/audio` (retourne `FileResponse`)
+  - `DELETE /api/v1/entries/{entry_id}` (supprime DB puis fichier)
 
 ### `services/api/app/settings.py`
 - Variables d'env/settings (avec defaults):
@@ -105,12 +105,12 @@
 - Lit `API_BASE_URL` (default `http://api:8000`) et `ALLOWED_TYPES` upload.
 - Sidebar: saisie `user_id`, affichage endpoint API.
 - Parcours utilisateur:
-  - vérification santé API (`GET /health`)
-  - récupération question (`GET /questions/today`)
-  - upload multipart (`POST /entries`)
-  - listing (`GET /entries?user_id=...`)
-  - lecture audio (`GET /entries/{id}/audio` via `st.audio`)
-  - suppression (`DELETE /entries/{id}` + rerun)
+  - vérification santé API (`GET /api/v1/health`)
+  - récupération question (`GET /api/v1/questions/today`)
+  - upload multipart (`POST /api/v1/entries`)
+  - listing (`GET /api/v1/entries?user_id=...`)
+  - lecture audio (`GET /api/v1/entries/{id}/audio` via `st.audio`)
+  - suppression (`DELETE /api/v1/entries/{id}` + rerun)
 - Gestion erreurs API via extraction JSON homogène (`api_json_error`).
 
 ### `docker-compose.yml`
@@ -145,7 +145,7 @@
   - API écrit `audio/{uuid}.{ext}` sous `settings.data_dir`.
   - En docker, `DATA_DIR=/app/data` et volume `./data:/app/data` => persiste sur host dans `./data/audio`.
 - **Persistance après redémarrage**: validée.
-  - Test manuel: création d'entrée audio, arrêt API, redémarrage API, `GET /entries/{id}/audio` retourne `200`.
+  - Test manuel: création d'entrée audio, arrêt API, redémarrage API, `GET /api/v1/entries/{id}/audio` retourne `200`.
 - **Web -> API via `API_BASE_URL` docker-compose**: cohérent.
   - Compose injecte `API_BASE_URL=${API_BASE_URL:-http://api:8000}` côté `web`.
   - L'app Streamlit lit `API_BASE_URL` et appelle cette base URL pour tous endpoints.
@@ -156,9 +156,9 @@
   - Résultat final: `3 passed`.
 - `cd services/api && python -c "import app.main; print('ok')"`
   - Import OK.
-- `curl http://127.0.0.1:8000/health`
+- `curl http://127.0.0.1:8000/api/v1/health`
   - `{"status":"ok"}`.
-- `curl http://127.0.0.1:8000/questions/today`
+- `curl http://127.0.0.1:8000/api/v1/questions/today`
   - Réponse 200 avec question seed.
 
 ## 5) Top 10 risques / bugs probables + reproduction
@@ -172,7 +172,7 @@
 4. **Limite taille en RAM** (lecture complète en mémoire)
    - Repro: upload proche de 25MB en parallèle x N requêtes => pression mémoire process.
 5. **Course condition suppression/lecture**
-   - Repro: lancer `GET /entries/{id}/audio` pendant `DELETE /entries/{id}` => intermittence 404.
+   - Repro: lancer `GET /api/v1/entries/{id}/audio` pendant `DELETE /api/v1/entries/{id}` => intermittence 404.
 6. **Orphelins fichiers si crash entre write disque et commit DB**
    - Repro: simuler crash après `write_bytes` avant `db.commit` => fichier présent sans entrée DB.
 7. **Orphelins DB si crash après commit avant unlink delete**
@@ -186,10 +186,10 @@
 
 ## 6) Checklist “Phase 2 DONE” (critères vérifiables)
 
-- [ ] Lancer local sans Docker (`uvicorn app.main:app`) + `/health` OK
+- [ ] Lancer local sans Docker (`uvicorn app.main:app`) + `/api/v1/health` OK
 - [ ] Lancer Docker (`docker compose up --build`) + API/Web accessibles
 - [ ] Upload audio OK (MIME autorisé, <=25MB)
-- [ ] Lecture audio OK (`GET /entries/{id}/audio` + Streamlit)
+- [ ] Lecture audio OK (`GET /api/v1/entries/{id}/audio` + Streamlit)
 - [ ] Suppression OK (DB + fichier supprimés)
 - [ ] Redémarrage conserve la bibliothèque (DB SQLite + fichiers audio persistants)
 - [ ] Tests API verts (`pytest`)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 import uuid
 
-from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy import inspect, select
@@ -16,6 +16,7 @@ from app.settings import settings
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 logger = logging.getLogger(__name__)
+api_v1_router = APIRouter(prefix="/api/v1")
 
 ALLOWED_MIME_TYPES = {
     "audio/mpeg": ".mp3",
@@ -81,12 +82,12 @@ def generic_exception_handler(_, __: Exception) -> JSONResponse:
     )
 
 
-@app.get("/health")
+@api_v1_router.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.get("/version")
+@api_v1_router.get("/version")
 def version() -> dict[str, str]:
     return {"name": settings.app_name, "version": settings.app_version}
 
@@ -100,7 +101,7 @@ def _ensure_questions_seeded(db: Session) -> None:
     db.commit()
 
 
-@app.get("/questions/today", response_model=QuestionOut)
+@api_v1_router.get("/questions/today", response_model=QuestionOut)
 def get_question_today(db: Session = Depends(get_db)) -> Question:
     _ensure_questions_seeded(db)
     questions = db.execute(select(Question).where(Question.is_active.is_(True)).order_by(Question.id)).scalars().all()
@@ -110,7 +111,7 @@ def get_question_today(db: Session = Depends(get_db)) -> Question:
     return selected
 
 
-@app.post("/entries", response_model=EntryOut)
+@api_v1_router.post("/entries", response_model=EntryOut)
 async def create_entry(
     user_id: str = Form(...),
     question_id: int = Form(...),
@@ -154,7 +155,7 @@ async def create_entry(
     return entry
 
 
-@app.get("/entries", response_model=list[EntryOut])
+@api_v1_router.get("/entries", response_model=list[EntryOut])
 def list_entries(user_id: str = Query(...), db: Session = Depends(get_db)) -> list[Entry]:
     entries = (
         db.execute(select(Entry).where(Entry.user_id == user_id).order_by(Entry.created_at.desc()))
@@ -164,7 +165,7 @@ def list_entries(user_id: str = Query(...), db: Session = Depends(get_db)) -> li
     return entries
 
 
-@app.get("/entries/{entry_id}", response_model=EntryOut)
+@api_v1_router.get("/entries/{entry_id}", response_model=EntryOut)
 def get_entry(entry_id: str, db: Session = Depends(get_db)) -> Entry:
     entry = db.get(Entry, entry_id)
     if entry is None:
@@ -172,7 +173,7 @@ def get_entry(entry_id: str, db: Session = Depends(get_db)) -> Entry:
     return entry
 
 
-@app.get("/entries/{entry_id}/audio")
+@api_v1_router.get("/entries/{entry_id}/audio")
 def get_entry_audio(entry_id: str, db: Session = Depends(get_db)) -> FileResponse:
     entry = db.get(Entry, entry_id)
     if entry is None:
@@ -183,7 +184,7 @@ def get_entry_audio(entry_id: str, db: Session = Depends(get_db)) -> FileRespons
     return FileResponse(path=path, media_type=entry.audio_mime, filename=path.name)
 
 
-@app.delete("/entries/{entry_id}")
+@api_v1_router.delete("/entries/{entry_id}")
 def delete_entry(entry_id: str, db: Session = Depends(get_db)) -> dict[str, str]:
     entry = db.get(Entry, entry_id)
     if entry is None:
@@ -194,3 +195,6 @@ def delete_entry(entry_id: str, db: Session = Depends(get_db)) -> dict[str, str]
     db.commit()
     path.unlink(missing_ok=True)
     return {"status": "deleted", "id": entry_id}
+
+
+app.include_router(api_v1_router)

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -5,6 +5,9 @@ from alembic.config import Config
 from fastapi.testclient import TestClient
 
 
+API_PREFIX = "/api/v1"
+
+
 def _build_client(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
 
@@ -32,7 +35,7 @@ def _build_client(tmp_path, monkeypatch):
 
 
 def _create_entry(client: TestClient, user_id: str = "alice") -> dict:
-    question = client.get("/questions/today")
+    question = client.get(f"{API_PREFIX}/questions/today")
     assert question.status_code == 200
 
     payload = {
@@ -41,7 +44,7 @@ def _create_entry(client: TestClient, user_id: str = "alice") -> dict:
     }
     files = {"audio_file": ("voice.mp3", BytesIO(b"fake-audio"), "audio/mpeg")}
 
-    created = client.post("/entries", data=payload, files=files)
+    created = client.post(f"{API_PREFIX}/entries", data=payload, files=files)
     assert created.status_code == 200
     return created.json()
 
@@ -51,30 +54,30 @@ def test_create_list_delete_entry(tmp_path, monkeypatch):
 
     created_body = _create_entry(client)
 
-    listed = client.get("/entries", params={"user_id": "alice"})
+    listed = client.get(f"{API_PREFIX}/entries", params={"user_id": "alice"})
     assert listed.status_code == 200
     assert len(listed.json()) == 1
 
-    audio = client.get(f"/entries/{created_body['id']}/audio")
+    audio = client.get(f"{API_PREFIX}/entries/{created_body['id']}/audio")
     assert audio.status_code == 200
 
-    deleted = client.delete(f"/entries/{created_body['id']}")
+    deleted = client.delete(f"{API_PREFIX}/entries/{created_body['id']}")
     assert deleted.status_code == 200
 
-    listed_again = client.get("/entries", params={"user_id": "alice"})
+    listed_again = client.get(f"{API_PREFIX}/entries", params={"user_id": "alice"})
     assert listed_again.status_code == 200
     assert listed_again.json() == []
 
 
 def test_404_entry(tmp_path, monkeypatch):
     client = _build_client(tmp_path, monkeypatch)
-    response = client.get("/entries/not-found")
+    response = client.get(f"{API_PREFIX}/entries/not-found")
     assert response.status_code == 404
 
 
 def test_mime_validation(tmp_path, monkeypatch):
     client = _build_client(tmp_path, monkeypatch)
-    question = client.get("/questions/today")
+    question = client.get(f"{API_PREFIX}/questions/today")
 
     payload = {
         "user_id": "bob",
@@ -82,7 +85,7 @@ def test_mime_validation(tmp_path, monkeypatch):
     }
     files = {"audio_file": ("voice.txt", BytesIO(b"not-audio"), "text/plain")}
 
-    response = client.post("/entries", data=payload, files=files)
+    response = client.post(f"{API_PREFIX}/entries", data=payload, files=files)
     assert response.status_code == 422
     assert response.json() == {
         "error": {
@@ -94,10 +97,10 @@ def test_mime_validation(tmp_path, monkeypatch):
 
 def test_upload_accepts_audio_x_m4a(tmp_path, monkeypatch):
     client = _build_client(tmp_path, monkeypatch)
-    question_id = client.get("/questions/today").json()["id"]
+    question_id = client.get(f"{API_PREFIX}/questions/today").json()["id"]
 
     response = client.post(
-        "/entries",
+        f"{API_PREFIX}/entries",
         data={"user_id": "eve", "question_id": str(question_id)},
         files={"audio_file": ("voice.m4a", BytesIO(b"m4a"), "audio/x-m4a")},
     )
@@ -108,10 +111,10 @@ def test_upload_accepts_audio_x_m4a(tmp_path, monkeypatch):
 
 def test_upload_accepts_audio_webm(tmp_path, monkeypatch):
     client = _build_client(tmp_path, monkeypatch)
-    question_id = client.get("/questions/today").json()["id"]
+    question_id = client.get(f"{API_PREFIX}/questions/today").json()["id"]
 
     response = client.post(
-        "/entries",
+        f"{API_PREFIX}/entries",
         data={"user_id": "eve", "question_id": str(question_id)},
         files={"audio_file": ("voice.webm", BytesIO(b"webm"), "audio/webm")},
     )
@@ -122,13 +125,23 @@ def test_upload_accepts_audio_webm(tmp_path, monkeypatch):
 
 def test_upload_accepts_audio_3gpp(tmp_path, monkeypatch):
     client = _build_client(tmp_path, monkeypatch)
-    question_id = client.get("/questions/today").json()["id"]
+    question_id = client.get(f"{API_PREFIX}/questions/today").json()["id"]
 
     response = client.post(
-        "/entries",
+        f"{API_PREFIX}/entries",
         data={"user_id": "eve", "question_id": str(question_id)},
         files={"audio_file": ("voice.3gp", BytesIO(b"3gpp"), "audio/3gpp")},
     )
 
     assert response.status_code == 200
     assert response.json()["audio_mime"] == "audio/3gpp"
+
+
+def test_legacy_root_endpoints_removed(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    assert client.get("/health").status_code == 404
+    assert client.get("/version").status_code == 404
+    assert client.get("/questions/today").status_code == 404
+    assert client.get("/entries", params={"user_id": "alice"}).status_code == 404
+    assert client.get("/entries/not-found").status_code == 404


### PR DESCRIPTION
### Motivation
- Ensure all public documentation consistently references the versioned API prefix `/api/v1` after the router change. 
- Make automated tests assert legacy (root) endpoints are removed and return `404` to avoid regressions. 
- Confirm no docker-compose healthchecks still reference unversioned root endpoints.

### Description
- Updated `docs/phase2-report.md` Routes section so every endpoint is documented under `/api/v1/...` (POST/GET/DELETE on `entries`, question routes, health/version, etc.).
- Extended `services/api/tests/test_entries.py` to use `API_PREFIX = "/api/v1"` for API calls and updated all tests to call the versioned endpoints.
- Completed `test_legacy_root_endpoints_removed` to assert `GET /version -> 404` and added an optional `GET /entries/not-found -> 404` check; kept existing checks for `/health`, `/questions/today`, and `/entries` root paths.
- Searched `docker-compose.yml` and `docker-compose.sandbox.yml` for healthcheck or root `/health`/`/version` usages and found no healthcheck entries to update.

### Testing
- Ran a search for `/health` and `/version` in compose/docs/tests and verified no compose healthchecks needed changing, which completed successfully. 
- Ran the service API test suite with `cd services/api && pytest -q` and all tests passed: `7 passed` with `2` FastAPI deprecation warnings. 
- Verified the modified tests execute against the versioned router and assert legacy root endpoints return `404` as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc847faac8330a4dd061e5a6e84d6)