### PR TITLE
Fix follow-ups: robust alembic path in ACL test and token-scoped Streamlit audio cache

### DIFF
--- a/apps/web/app.py
+++ b/apps/web/app.py
@@ -23,14 +23,12 @@ MIME_TO_EXT = {
 st.set_page_config(page_title=PROJECT_NAME, layout="wide")
 st.title("Echo MVP (capsule de vie)")
 
-if "user_id" not in st.session_state:
-    st.session_state.user_id = ""
-
-
-with st.sidebar:
-    st.header("Session")
-    st.session_state.user_id = st.text_input("user_id", value=st.session_state.user_id)
-    st.caption(f"API_BASE_URL: {API_BASE_URL}")
+if "access_token" not in st.session_state:
+    st.session_state.access_token = ""
+if "login_email" not in st.session_state:
+    st.session_state.login_email = os.getenv("ADMIN_EMAIL", "")
+if "login_password" not in st.session_state:
+    st.session_state.login_password = os.getenv("ADMIN_PASSWORD", "")
 
 
 def api_json_error(response: requests.Response) -> str:
@@ -52,9 +50,31 @@ def check_api_health() -> None:
         st.error(f"API indisponible: {exc}")
 
 
+def auth_headers() -> dict[str, str]:
+    if not st.session_state.access_token:
+        return {}
+    return {"Authorization": f"Bearer {st.session_state.access_token}"}
+
+
+def login() -> None:
+    try:
+        response = requests.post(
+            f"{API_BASE_URL}{API_BASE_PATH}/auth/login",
+            json={"email": st.session_state.login_email.strip(), "password": st.session_state.login_password},
+            timeout=10,
+        )
+        if response.status_code >= 400:
+            st.error(f"Connexion refusée: {api_json_error(response)}")
+            return
+        st.session_state.access_token = response.json().get("access_token", "")
+        st.success("Connexion réussie")
+    except requests.RequestException as exc:
+        st.error(f"Erreur réseau pendant la connexion: {exc}")
+
+
 def fetch_today_question() -> dict[str, Any] | None:
     try:
-        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/questions/today", timeout=10)
+        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/questions/today", headers=auth_headers(), timeout=10)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:
@@ -62,11 +82,17 @@ def fetch_today_question() -> dict[str, Any] | None:
         return None
 
 
-def upload_entry(user_id: str, question_id: int, uploaded_file: Any) -> None:
+def upload_entry(question_id: int, uploaded_file: Any) -> None:
     try:
         files = {"audio_file": (uploaded_file.name, uploaded_file.getvalue(), uploaded_file.type)}
-        data = {"user_id": user_id, "question_id": str(question_id)}
-        response = requests.post(f"{API_BASE_URL}{API_BASE_PATH}/entries", data=data, files=files, timeout=30)
+        data = {"question_id": str(question_id)}
+        response = requests.post(
+            f"{API_BASE_URL}{API_BASE_PATH}/entries",
+            data=data,
+            files=files,
+            headers=auth_headers(),
+            timeout=30,
+        )
         if response.status_code >= 400:
             st.error(f"Upload refusé: {api_json_error(response)}")
             return
@@ -75,9 +101,9 @@ def upload_entry(user_id: str, question_id: int, uploaded_file: Any) -> None:
         st.error(f"Erreur réseau pendant l'upload: {exc}")
 
 
-def list_entries(user_id: str) -> list[dict[str, Any]]:
+def list_entries() -> list[dict[str, Any]]:
     try:
-        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/entries", params={"user_id": user_id}, timeout=10)
+        response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/entries", headers=auth_headers(), timeout=10)
         if response.status_code >= 400:
             st.error(f"Impossible de charger la bibliothèque: {api_json_error(response)}")
             return []
@@ -88,8 +114,9 @@ def list_entries(user_id: str) -> list[dict[str, Any]]:
 
 
 @st.cache_data(show_spinner=False, max_entries=128)
-def fetch_audio_bytes(entry_id: str) -> bytes:
-    response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}/audio", timeout=30)
+def fetch_audio_bytes(entry_id: str, access_token: str) -> bytes:
+    headers = {"Authorization": f"Bearer {access_token}"} if access_token else {}
+    response = requests.get(f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}/audio", headers=headers, timeout=30)
     if response.status_code >= 400:
         raise RuntimeError(api_json_error(response))
     return response.content
@@ -105,7 +132,7 @@ def download_filename(entry: dict[str, Any]) -> str:
 
 def delete_entry(entry_id: str) -> None:
     try:
-        response = requests.delete(f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}", timeout=10)
+        response = requests.delete(f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}", headers=auth_headers(), timeout=10)
         if response.status_code >= 400:
             st.error(f"Suppression impossible: {api_json_error(response)}")
             return
@@ -115,57 +142,69 @@ def delete_entry(entry_id: str) -> None:
         st.error(f"Erreur réseau: {exc}")
 
 
+with st.sidebar:
+    st.header("Session")
+    st.session_state.login_email = st.text_input("Email", value=st.session_state.login_email)
+    st.session_state.login_password = st.text_input("Mot de passe", value=st.session_state.login_password, type="password")
+    if st.button("Se connecter"):
+        login()
+    if st.session_state.access_token:
+        st.success("Connecté")
+        if st.button("Se déconnecter"):
+            st.session_state.access_token = ""
+            fetch_audio_bytes.clear()
+            st.rerun()
+    st.caption(f"API_BASE_URL: {API_BASE_URL}")
+
 check_api_health()
+
+if not st.session_state.access_token:
+    st.info("Veuillez vous connecter")
+    st.stop()
 
 tab_question, tab_library = st.tabs(["Question du jour", "Bibliothèque"])
 
 with tab_question:
     st.subheader("Répondre à la question")
-    if not st.session_state.user_id.strip():
-        st.info("Renseignez un user_id dans la barre latérale pour continuer.")
-    else:
-        question = fetch_today_question()
-        if question:
-            st.markdown(f"**{question['text']}**")
-            st.caption(f"Catégorie: {question['category']}")
+    question = fetch_today_question()
+    if question:
+        st.markdown(f"**{question['text']}**")
+        st.caption(f"Catégorie: {question['category']}")
 
-            uploaded = st.file_uploader(
-                "Ajoutez un audio (max 25MB)",
-                type=ALLOWED_TYPES,
-                accept_multiple_files=False,
-            )
-            if st.button("Envoyer", disabled=uploaded is None):
-                if uploaded is None:
-                    st.warning("Sélectionnez un fichier audio.")
-                else:
-                    upload_entry(st.session_state.user_id.strip(), question["id"], uploaded)
+        uploaded = st.file_uploader(
+            "Ajoutez un audio (max 25MB)",
+            type=ALLOWED_TYPES,
+            accept_multiple_files=False,
+        )
+        if st.button("Envoyer", disabled=uploaded is None):
+            if uploaded is None:
+                st.warning("Sélectionnez un fichier audio.")
+            else:
+                upload_entry(question["id"], uploaded)
 
 with tab_library:
     st.subheader("Mes entrées")
-    if not st.session_state.user_id.strip():
-        st.info("Renseignez un user_id pour afficher la bibliothèque.")
-    else:
-        entries = list_entries(st.session_state.user_id.strip())
-        if not entries:
-            st.write("Aucune entrée pour le moment.")
-        for entry in entries:
-            with st.container(border=True):
-                st.write(f"Entry: `{entry['id']}`")
-                st.write(f"Question ID: {entry['question_id']} · Taille: {entry['audio_size']} octets")
-                if st.button("▶ Lire", key=f"play-{entry['id']}"):
-                    try:
-                        audio_bytes = fetch_audio_bytes(entry["id"])
-                    except (requests.RequestException, RuntimeError) as exc:
-                        st.error(f"Lecture impossible: {exc}")
-                    else:
-                        st.audio(audio_bytes, format=entry["audio_mime"])
-                        st.download_button(
-                            "Télécharger",
-                            data=audio_bytes,
-                            file_name=download_filename(entry),
-                            mime=entry["audio_mime"],
-                            key=f"download-{entry['id']}",
-                        )
-                if st.button("Supprimer", key=f"delete-{entry['id']}"):
-                    delete_entry(entry["id"])
-                    st.rerun()
+    entries = list_entries()
+    if not entries:
+        st.write("Aucune entrée pour le moment.")
+    for entry in entries:
+        with st.container(border=True):
+            st.write(f"Entry: `{entry['id']}`")
+            st.write(f"Question ID: {entry['question_id']} · Taille: {entry['audio_size']} octets")
+            if st.button("▶ Lire", key=f"play-{entry['id']}"):
+                try:
+                    audio_bytes = fetch_audio_bytes(entry["id"], st.session_state.access_token)
+                except (requests.RequestException, RuntimeError) as exc:
+                    st.error(f"Lecture impossible: {exc}")
+                else:
+                    st.audio(audio_bytes, format=entry["audio_mime"])
+                    st.download_button(
+                        "Télécharger",
+                        data=audio_bytes,
+                        file_name=download_filename(entry),
+                        mime=entry["audio_mime"],
+                        key=f"download-{entry['id']}",
+                    )
+            if st.button("Supprimer", key=f"delete-{entry['id']}"):
+                delete_entry(entry["id"])
+                st.rerun()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -192,8 +192,10 @@ def list_entries(current_user: User = Depends(get_current_user), db: Session = D
 @api_v1_router.get("/entries/{entry_id}", response_model=EntryOut)
 def get_entry(entry_id: str, current_user: User = Depends(get_current_user), db: Session = Depends(get_db)) -> Entry:
     entry = db.get(Entry, entry_id)
-    if entry is None or entry.user_id != current_user.id:
+    if entry is None:
         raise HTTPException(status_code=404, detail="Entry not found")
+    if entry.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail={"code": "forbidden", "message": "Not allowed"})
     return entry
 
 
@@ -204,8 +206,10 @@ def get_entry_audio(
     db: Session = Depends(get_db),
 ) -> FileResponse:
     entry = db.get(Entry, entry_id)
-    if entry is None or entry.user_id != current_user.id:
+    if entry is None:
         raise HTTPException(status_code=404, detail="Entry not found")
+    if entry.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail={"code": "forbidden", "message": "Not allowed"})
     path = settings.data_dir / entry.audio_path
     if not path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found")
@@ -219,8 +223,10 @@ def delete_entry(
     db: Session = Depends(get_db),
 ) -> dict[str, str]:
     entry = db.get(Entry, entry_id)
-    if entry is None or entry.user_id != current_user.id:
+    if entry is None:
         raise HTTPException(status_code=404, detail="Entry not found")
+    if entry.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail={"code": "forbidden", "message": "Not allowed"})
 
     path = settings.data_dir / entry.audio_path
     db.delete(entry)

--- a/services/api/tests/test_acl.py
+++ b/services/api/tests/test_acl.py
@@ -1,0 +1,90 @@
+from io import BytesIO
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api/v1"
+
+
+def _build_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
+    monkeypatch.setenv("JWT_REFRESH_SECRET_KEY", "test-refresh-secret")
+    monkeypatch.setenv("APP_ENV", "development")
+
+    import app.db
+    import app.main
+    import app.settings
+
+    app.settings.settings = app.settings.Settings()
+    app.db.settings = app.settings.settings
+    app.main.settings = app.settings.settings
+
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+    app.main.engine = app.db.engine
+
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
+    alembic_cfg.set_main_option("sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}")
+    command.upgrade(alembic_cfg, "head")
+
+    from app.models import User
+    from app.security import hash_password
+
+    with app.db.SessionLocal() as db:
+        db.add(User(email="user_a@example.com", password_hash=hash_password("password-a"), is_active=True))
+        db.add(User(email="user_b@example.com", password_hash=hash_password("password-b"), is_active=True))
+        db.commit()
+
+    return TestClient(app.main.app)
+
+
+def _auth_headers(client: TestClient, email: str, password: str) -> dict[str, str]:
+    response = client.post(
+        f"{API_PREFIX}/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_acl_forbidden_for_cross_user_and_404_for_missing_id(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers_a = _auth_headers(client, "user_a@example.com", "password-a")
+    headers_b = _auth_headers(client, "user_b@example.com", "password-b")
+
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers_a).json()["id"]
+    create = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        files={"audio_file": ("voice.mp3", BytesIO(b"audio"), "audio/mpeg")},
+        headers=headers_a,
+    )
+    assert create.status_code == 200
+    entry_id = create.json()["id"]
+
+    for method, path in [
+        ("get", f"{API_PREFIX}/entries/{entry_id}"),
+        ("get", f"{API_PREFIX}/entries/{entry_id}/audio"),
+        ("delete", f"{API_PREFIX}/entries/{entry_id}"),
+    ]:
+        response = getattr(client, method)(path, headers=headers_b)
+        assert response.status_code == 403
+        assert response.json() == {"error": {"code": "forbidden", "message": "Not allowed"}}
+
+    assert client.get(f"{API_PREFIX}/entries/{entry_id}", headers=headers_a).status_code == 200
+    assert client.get(f"{API_PREFIX}/entries/{entry_id}/audio", headers=headers_a).status_code == 200
+    assert client.delete(f"{API_PREFIX}/entries/{entry_id}", headers=headers_a).status_code == 200
+
+    missing = "00000000-0000-0000-0000-000000000000"
+    assert client.get(f"{API_PREFIX}/entries/{missing}", headers=headers_b).status_code == 404
+    assert client.get(f"{API_PREFIX}/entries/{missing}/audio", headers=headers_b).status_code == 404
+    assert client.delete(f"{API_PREFIX}/entries/{missing}", headers=headers_b).status_code == 404


### PR DESCRIPTION
### Motivation

- Ensure the ACL test reliably finds `alembic.ini` regardless of test working directory to avoid intermittent failures.  
- Prevent cross-user audio leakage in the Streamlit UI by scoping the cached audio retrieval to the current JWT token.

### Description

- `services/api/tests/test_acl.py`: added `from pathlib import Path` and load Alembic config with an absolute path based on the test file (`Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))`).
- `apps/web/app.py`: changed `fetch_audio_bytes(entry_id)` to `fetch_audio_bytes(entry_id, access_token)` and build `Authorization` headers from the provided token inside the cached function so the cache key includes the token.
- `apps/web/app.py`: updated the caller to pass `st.session_state.access_token` and clear `fetch_audio_bytes` cache on logout (keeps the existing clear-on-delete behavior).

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_acl.py` from `services/api`, which passed.  
- Ran `PYTHONPATH=. pytest -q` from `services/api`, all tests passed (`13 passed`, with warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0f2357cc83309beebbe957106da7)