### PR TITLE
Add paginated and sortable /entries list with response wrapper and DB index

### DIFF
--- a/services/api/alembic/versions/0003_entries_list_indexes.py
+++ b/services/api/alembic/versions/0003_entries_list_indexes.py
@@ -1,0 +1,29 @@
+"""add entries list pagination indexes
+
+Revision ID: 0003_entries_list_indexes
+Revises: 0002_users_and_auth
+Create Date: 2026-02-24
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_entries_list_indexes"
+down_revision: Union[str, None] = "0002_users_and_auth"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_entries_user_id_created_at_id",
+        "entries",
+        ["user_id", "created_at", "id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_entries_user_id_created_at_id", table_name="entries")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,9 +1,10 @@
 from datetime import date
 import logging
 from pathlib import Path
+from typing import Literal
 import uuid
 
-from fastapi import APIRouter, Depends, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy import inspect, select
@@ -12,7 +13,7 @@ from sqlalchemy.orm import Session
 from app.db import engine, get_db
 from app.models import Entry, Question, User
 from app.routes.auth import router as auth_router
-from app.schemas import EntryOut, QuestionOut
+from app.schemas import EntriesListResponse, EntryOut, QuestionOut
 from app.security import get_current_user, hash_password
 from app.settings import settings
 
@@ -179,14 +180,34 @@ async def create_entry(
     return entry
 
 
-@api_v1_router.get("/entries", response_model=list[EntryOut])
-def list_entries(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)) -> list[Entry]:
+@api_v1_router.get("/entries", response_model=EntriesListResponse)
+def list_entries(
+    limit: int = Query(default=50, ge=1, description="Page size. Values above 200 are clamped to 200."),
+    offset: int = Query(default=0, ge=0),
+    sort: Literal["created_at_desc", "created_at_asc", "id_asc", "id_desc"] = "created_at_desc",
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> EntriesListResponse:
+    order_by_map = {
+        "created_at_desc": (Entry.created_at.desc(), Entry.id.desc()),
+        "created_at_asc": (Entry.created_at.asc(), Entry.id.asc()),
+        "id_asc": (Entry.id.asc(),),
+        "id_desc": (Entry.id.desc(),),
+    }
+    clamped_limit = min(limit, 200)
     entries = (
-        db.execute(select(Entry).where(Entry.user_id == current_user.id).order_by(Entry.created_at.desc()))
+        db.execute(
+            select(Entry)
+            .where(Entry.user_id == current_user.id)
+            .order_by(*order_by_map[sort])
+            .offset(offset)
+            .limit(clamped_limit)
+        )
         .scalars()
         .all()
     )
-    return entries
+    next_offset = offset + len(entries) if len(entries) == clamped_limit else None
+    return EntriesListResponse(items=entries, next_offset=next_offset, limit=clamped_limit, offset=offset)
 
 
 @api_v1_router.get("/entries/{entry_id}", response_model=EntryOut)

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -1,16 +1,27 @@
 from datetime import datetime
+from typing import Optional
 
+import pydantic
 from pydantic import BaseModel
 
 
-class QuestionOut(BaseModel):
+class ORMBaseModel(BaseModel):
+    if hasattr(pydantic, "ConfigDict"):
+        model_config = pydantic.ConfigDict(from_attributes=True)
+    else:
+
+        class Config:
+            orm_mode = True
+
+
+class QuestionOut(ORMBaseModel):
     id: int
     text: str
     category: str
     is_active: bool
 
 
-class EntryOut(BaseModel):
+class EntryOut(ORMBaseModel):
     id: str
     user_id: str
     question_id: int
@@ -19,5 +30,12 @@ class EntryOut(BaseModel):
     created_at: datetime
 
 
-class ErrorResponse(BaseModel):
+class EntriesListResponse(ORMBaseModel):
+    items: list[EntryOut]
+    next_offset: Optional[int] = None
+    limit: int
+    offset: int
+
+
+class ErrorResponse(ORMBaseModel):
     error: dict[str, str]

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -76,7 +76,7 @@ def test_create_list_delete_entry(tmp_path, monkeypatch):
 
     listed = client.get(f"{API_PREFIX}/entries", headers=headers)
     assert listed.status_code == 200
-    assert len(listed.json()) == 1
+    assert len(listed.json()["items"]) == 1
 
     audio = client.get(f"{API_PREFIX}/entries/{created_body['id']}/audio", headers=headers)
     assert audio.status_code == 200
@@ -86,7 +86,7 @@ def test_create_list_delete_entry(tmp_path, monkeypatch):
 
     listed_again = client.get(f"{API_PREFIX}/entries", headers=headers)
     assert listed_again.status_code == 200
-    assert listed_again.json() == []
+    assert listed_again.json()["items"] == []
 
 
 def test_404_entry(tmp_path, monkeypatch):

--- a/services/api/tests/test_entries_list.py
+++ b/services/api/tests/test_entries_list.py
@@ -1,0 +1,179 @@
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+
+from sqlalchemy import update
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api/v1"
+
+
+def _build_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
+    monkeypatch.setenv("JWT_REFRESH_SECRET_KEY", "test-refresh-secret")
+    monkeypatch.setenv("APP_ENV", "development")
+
+    import app.db
+    import app.main
+    import app.settings
+
+    app.settings.settings = app.settings.Settings()
+    app.db.settings = app.settings.settings
+    app.main.settings = app.settings.settings
+
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+    app.main.engine = app.db.engine
+
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
+    alembic_cfg.set_main_option("sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}")
+    command.upgrade(alembic_cfg, "head")
+
+    from app.models import User
+    from app.security import hash_password
+
+    with app.db.SessionLocal() as db:
+        db.add(User(email="user_a@example.com", password_hash=hash_password("password-a"), is_active=True))
+        db.add(User(email="user_b@example.com", password_hash=hash_password("password-b"), is_active=True))
+        db.commit()
+
+    return TestClient(app.main.app)
+
+
+def _auth_headers(client: TestClient, email: str, password: str) -> dict[str, str]:
+    response = client.post(f"{API_PREFIX}/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _create_entry(client: TestClient, headers: dict[str, str]) -> dict:
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()["id"]
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        files={"audio_file": ("voice.mp3", BytesIO(b"audio"), "audio/mpeg")},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def test_default_pagination_wrapper(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+
+    _create_entry(client, headers)
+
+    response = client.get(f"{API_PREFIX}/entries", headers=headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert isinstance(body["items"], list)
+    assert body["next_offset"] is None
+
+
+def test_limit_clamped_to_200(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+
+    response = client.get(f"{API_PREFIX}/entries?limit=999", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["limit"] == 200
+
+
+def test_limit_and_offset_validation(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+
+    bad_offset = client.get(f"{API_PREFIX}/entries?offset=-1", headers=headers)
+    assert bad_offset.status_code == 422
+
+    bad_limit = client.get(f"{API_PREFIX}/entries?limit=0", headers=headers)
+    assert bad_limit.status_code == 422
+
+
+def test_sort_created_at_asc_desc(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+
+    first = _create_entry(client, headers)
+    second = _create_entry(client, headers)
+
+    import app.db
+    from app.models import Entry
+
+    with app.db.SessionLocal() as db:
+        db.execute(
+            update(Entry).where(Entry.id == first["id"]).values(created_at=datetime(2024, 1, 1, tzinfo=timezone.utc))
+        )
+        db.execute(
+            update(Entry).where(Entry.id == second["id"]).values(created_at=datetime(2024, 1, 2, tzinfo=timezone.utc))
+        )
+        db.commit()
+
+    desc = client.get(f"{API_PREFIX}/entries?sort=created_at_desc", headers=headers)
+    asc = client.get(f"{API_PREFIX}/entries?sort=created_at_asc", headers=headers)
+
+    assert desc.status_code == 200
+    assert asc.status_code == 200
+    assert desc.json()["items"][0]["id"] == second["id"]
+    assert asc.json()["items"][0]["id"] == first["id"]
+
+
+def test_stable_pagination_with_tiebreaker(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+
+    created_ids = [_create_entry(client, headers)["id"] for _ in range(5)]
+
+    import app.db
+    from app.models import Entry
+
+    with app.db.SessionLocal() as db:
+        db.execute(
+            update(Entry)
+            .where(Entry.id.in_(created_ids))
+            .values(created_at=datetime(2024, 2, 1, tzinfo=timezone.utc))
+        )
+        db.commit()
+
+    page_1 = client.get(f"{API_PREFIX}/entries?sort=created_at_desc&limit=2&offset=0", headers=headers).json()
+    page_2 = client.get(f"{API_PREFIX}/entries?sort=created_at_desc&limit=2&offset=2", headers=headers).json()
+    page_3 = client.get(f"{API_PREFIX}/entries?sort=created_at_desc&limit=2&offset=4", headers=headers).json()
+
+    seen_ids = [item["id"] for item in page_1["items"] + page_2["items"] + page_3["items"]]
+    assert seen_ids == sorted(created_ids, reverse=True)
+    assert len(seen_ids) == len(set(seen_ids))
+    assert page_1["next_offset"] == 2
+    assert page_2["next_offset"] == 4
+    assert page_3["next_offset"] is None
+
+
+def test_entries_list_acl_isolated_by_user(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers_a = _auth_headers(client, "user_a@example.com", "password-a")
+    headers_b = _auth_headers(client, "user_b@example.com", "password-b")
+
+    entry_a1 = _create_entry(client, headers_a)["id"]
+    entry_a2 = _create_entry(client, headers_a)["id"]
+    entry_b1 = _create_entry(client, headers_b)["id"]
+
+    list_a = client.get(f"{API_PREFIX}/entries?limit=10&offset=0", headers=headers_a)
+    list_b = client.get(f"{API_PREFIX}/entries?limit=10&offset=0", headers=headers_b)
+
+    assert list_a.status_code == 200
+    assert list_b.status_code == 200
+    ids_a = {item["id"] for item in list_a.json()["items"]}
+    ids_b = {item["id"] for item in list_b.json()["items"]}
+    assert ids_a == {entry_a1, entry_a2}
+    assert ids_b == {entry_b1}


### PR DESCRIPTION
### Motivation

- Provide stable, paginated access to user entries with server-side clamping and deterministic ordering for pagination.  
- Improve query performance for common pagination patterns by adding a composite index on `(user_id, created_at, id)`.

### Description

- Change `GET /entries` to accept `limit`, `offset`, and `sort` query parameters and return a wrapper `EntriesListResponse` containing `items`, `limit`, `offset`, and `next_offset` instead of a raw list.  
- Add stable multi-column ordering with a tiebreaker using `id` and clamp `limit` to a maximum of `200`.  
- Introduce `ORMBaseModel` to support both Pydantic v2 (`ConfigDict`) and v1 (`orm_mode`) and convert `EntryOut`/`QuestionOut`/`ErrorResponse` to inherit it; add `EntriesListResponse` schema.  
- Add Alembic migration `0003_entries_list_indexes` which creates index `ix_entries_user_id_created_at_id` and update tests to expect the new response shape; add `test_entries_list.py` with pagination, sorting and ACL tests.  

### Testing

- Ran the API test suite for the service (`services/api/tests`), including updated `test_entries.py` and the new `test_entries_list.py`, and all tests passed.  
- Executed Alembic `upgrade` in tests to apply `0003_entries_list_indexes` migration successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e28d2b83483309a08cdb233d5334a)