### PR TITLE
Add streaming audio upload with signature validation and audio metadata (SHA256, duration)

### DIFF
--- a/services/api/alembic/versions/0004_entry_audio_metadata.py
+++ b/services/api/alembic/versions/0004_entry_audio_metadata.py
@@ -1,0 +1,30 @@
+"""add entry audio hash and duration columns
+
+Revision ID: 0004_entry_audio_metadata
+Revises: 0003_entries_list_indexes
+Create Date: 2026-02-25
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_entry_audio_metadata"
+down_revision: Union[str, None] = "0003_entries_list_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "entries",
+        sa.Column("audio_sha256", sa.String(length=64), nullable=False, server_default="0" * 64),
+    )
+    op.add_column("entries", sa.Column("audio_duration_ms", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("entries", "audio_duration_ms")
+    op.drop_column("entries", "audio_sha256")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -16,24 +16,11 @@ from app.routes.auth import router as auth_router
 from app.schemas import EntriesListResponse, EntryOut, QuestionOut
 from app.security import get_current_user, hash_password
 from app.settings import settings
+from app.storage import ALLOWED_MIME_TYPES, stream_upload_to_disk
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 logger = logging.getLogger(__name__)
 api_v1_router = APIRouter(prefix="/api/v1")
-
-ALLOWED_MIME_TYPES = {
-    "audio/mpeg": ".mp3",
-    "audio/mp4": ".m4a",
-    "audio/x-m4a": ".m4a",
-    "audio/wav": ".wav",
-    "audio/x-wav": ".wav",
-    "audio/ogg": ".ogg",
-    "audio/aac": ".aac",
-    "audio/3gpp": ".3gp",
-    "audio/3gpp2": ".3g2",
-    "audio/webm": ".webm",
-    "audio/aiff": ".aiff",
-}
 
 SEED_QUESTIONS: list[tuple[str, str]] = [
     ("Quel moment t'a fait sourire aujourd'hui ?", "gratitude"),
@@ -155,16 +142,17 @@ async def create_entry(
             detail={"code": "unsupported_mime", "message": "Unsupported audio MIME type"},
         )
 
-    file_bytes = await audio_file.read()
-    if len(file_bytes) > settings.max_upload_bytes:
-        raise HTTPException(status_code=413, detail="Audio file exceeds 25 MB")
-
     entry_id = str(uuid.uuid4())
     ext = ALLOWED_MIME_TYPES[content_type]
     relative_path = Path("audio") / f"{entry_id}{ext}"
     absolute_path = settings.data_dir / relative_path
-    absolute_path.parent.mkdir(parents=True, exist_ok=True)
-    absolute_path.write_bytes(file_bytes)
+    upload_info = await stream_upload_to_disk(
+        upload=audio_file,
+        dst_path=absolute_path,
+        max_bytes=settings.max_upload_bytes,
+        expected_mime=content_type,
+        expected_ext=ext,
+    )
 
     entry = Entry(
         id=entry_id,
@@ -172,7 +160,9 @@ async def create_entry(
         question_id=question_id,
         audio_path=str(relative_path),
         audio_mime=content_type,
-        audio_size=len(file_bytes),
+        audio_size=int(upload_info["size"]),
+        audio_sha256=str(upload_info["sha256"]),
+        audio_duration_ms=upload_info["duration_ms"],
     )
     db.add(entry)
     db.commit()

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -37,6 +37,8 @@ class Entry(Base):
     audio_path: Mapped[str] = mapped_column(String, nullable=False)
     audio_mime: Mapped[str] = mapped_column(String, nullable=False)
     audio_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    audio_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    audio_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/services/api/app/storage.py
+++ b/services/api/app/storage.py
@@ -1,0 +1,160 @@
+import hashlib
+import os
+from pathlib import Path
+from typing import Optional
+import wave
+
+from fastapi import HTTPException, UploadFile
+
+CHUNK_SIZE = 1024 * 1024
+
+ALLOWED_MIME_TYPES = {
+    "audio/mpeg": ".mp3",
+    "audio/mp4": ".m4a",
+    "audio/x-m4a": ".m4a",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/ogg": ".ogg",
+    "audio/aac": ".aac",
+    "audio/3gpp": ".3gp",
+    "audio/3gpp2": ".3g2",
+    "audio/webm": ".webm",
+    "audio/aiff": ".aiff",
+}
+
+ALLOWED_EXTENSIONS_BY_MIME = {
+    "audio/mp4": {".m4a", ".mp4"},
+    "audio/x-m4a": {".m4a", ".mp4"},
+    "audio/ogg": {".ogg", ".oga"},
+    "audio/aiff": {".aiff", ".aif"},
+}
+
+WAV_MIME_TYPES = {"audio/wav", "audio/x-wav"}
+MP4_FAMILY_MIME_TYPES = {"audio/mp4", "audio/x-m4a", "audio/3gpp", "audio/3gpp2"}
+
+
+def _has_mp3_signature(header: bytes) -> bool:
+    if header.startswith(b"ID3"):
+        return True
+    if len(header) < 2:
+        return False
+    return header[0] == 0xFF and (header[1] & 0xE0) == 0xE0
+
+
+def _has_wav_signature(header: bytes) -> bool:
+    return len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WAVE"
+
+
+def _has_ogg_signature(header: bytes) -> bool:
+    return header.startswith(b"OggS")
+
+
+def _has_mp4_signature(header: bytes) -> bool:
+    return len(header) >= 8 and header[4:8] == b"ftyp"
+
+
+def _has_webm_signature(header: bytes) -> bool:
+    return header.startswith(b"\x1A\x45\xDF\xA3")
+
+
+def _has_aac_adts_signature(header: bytes) -> bool:
+    if len(header) < 2:
+        return False
+    if header[0] != 0xFF:
+        return False
+    return header[1] in {0xF1, 0xF9}
+
+
+def has_valid_signature(header: bytes, mime_type: str) -> bool:
+    if mime_type == "audio/mpeg":
+        return _has_mp3_signature(header)
+    if mime_type in WAV_MIME_TYPES:
+        return _has_wav_signature(header)
+    if mime_type == "audio/ogg":
+        return _has_ogg_signature(header)
+    if mime_type in MP4_FAMILY_MIME_TYPES:
+        return _has_mp4_signature(header)
+    if mime_type == "audio/webm":
+        return _has_webm_signature(header)
+    if mime_type == "audio/aac":
+        return _has_aac_adts_signature(header)
+    if mime_type == "audio/aiff":
+        return len(header) >= 12 and header.startswith(b"FORM") and header[8:12] == b"AIFF"
+    return False
+
+
+def _try_get_wav_duration_ms(path: Path) -> Optional[int]:
+    try:
+        with wave.open(str(path), "rb") as wav_file:
+            frame_rate = wav_file.getframerate()
+            if frame_rate <= 0:
+                return None
+            frames = wav_file.getnframes()
+            return int((frames / frame_rate) * 1000)
+    except (wave.Error, EOFError):
+        return None
+
+
+async def stream_upload_to_disk(
+    upload: UploadFile,
+    dst_path: Path,
+    max_bytes: int,
+    expected_mime: str,
+    expected_ext: str,
+) -> dict[str, Optional[int] | str]:
+    suffix = Path(upload.filename or "").suffix.lower()
+    allowed = ALLOWED_EXTENSIONS_BY_MIME.get(expected_mime, {expected_ext.lower()})
+    if suffix not in allowed:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "invalid_extension", "message": "Filename extension does not match MIME type"},
+        )
+
+    header = await upload.read(512)
+    if not header or not has_valid_signature(header, expected_mime):
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "invalid_signature", "message": "Audio signature does not match MIME type"},
+        )
+
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = dst_path.with_name(f"{dst_path.name}.{os.urandom(6).hex()}.tmp")
+    size = 0
+    digest = hashlib.sha256()
+
+    try:
+        with tmp_path.open("wb") as handle:
+            size += len(header)
+            if size > max_bytes:
+                raise HTTPException(
+                    status_code=413,
+                    detail={"code": "payload_too_large", "message": "Audio file exceeds upload size limit"},
+                )
+            digest.update(header)
+            handle.write(header)
+
+            while True:
+                to_read = min(CHUNK_SIZE, max(1, max_bytes - size + 1))
+                chunk = await upload.read(to_read)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > max_bytes:
+                    raise HTTPException(
+                        status_code=413,
+                        detail={"code": "payload_too_large", "message": "Audio file exceeds upload size limit"},
+                    )
+                digest.update(chunk)
+                handle.write(chunk)
+
+        os.replace(tmp_path, dst_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    duration_ms = _try_get_wav_duration_ms(dst_path) if expected_mime in WAV_MIME_TYPES else None
+    return {
+        "sha256": digest.hexdigest(),
+        "size": size,
+        "duration_ms": duration_ms,
+    }

--- a/services/api/tests/test_acl.py
+++ b/services/api/tests/test_acl.py
@@ -8,6 +8,9 @@ from fastapi.testclient import TestClient
 API_PREFIX = "/api/v1"
 
 
+VALID_MP3_BYTES = b"ID3\x04\x00\x00\x00\x00\x00\x00payload"
+
+
 def _build_client(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
@@ -65,7 +68,7 @@ def test_acl_forbidden_for_cross_user_and_404_for_missing_id(tmp_path, monkeypat
     create = client.post(
         f"{API_PREFIX}/entries",
         data={"question_id": str(question_id)},
-        files={"audio_file": ("voice.mp3", BytesIO(b"audio"), "audio/mpeg")},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
         headers=headers_a,
     )
     assert create.status_code == 200

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -7,6 +7,12 @@ from fastapi.testclient import TestClient
 API_PREFIX = "/api/v1"
 
 
+VALID_MP3_BYTES = b"ID3\x04\x00\x00\x00\x00\x00\x00payload"
+VALID_M4A_BYTES = b"\x00\x00\x00\x18ftypM4A \x00\x00\x00\x00"
+VALID_WEBM_BYTES = b"\x1A\x45\xDF\xA3\x9F\x42\x86\x81\x01"
+VALID_3GPP_BYTES = b"\x00\x00\x00\x14ftyp3gp5\x00\x00\x00\x00"
+
+
 def _build_client(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
@@ -62,7 +68,7 @@ def _create_entry(client: TestClient) -> tuple[dict, dict[str, str]]:
     assert question.status_code == 200
 
     payload = {"question_id": str(question.json()["id"])}
-    files = {"audio_file": ("voice.mp3", BytesIO(b"fake-audio"), "audio/mpeg")}
+    files = {"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")}
 
     created = client.post(f"{API_PREFIX}/entries", data=payload, files=files, headers=headers)
     assert created.status_code == 200
@@ -122,7 +128,7 @@ def test_upload_accepts_audio_x_m4a(tmp_path, monkeypatch):
     response = client.post(
         f"{API_PREFIX}/entries",
         data={"question_id": str(question_id)},
-        files={"audio_file": ("voice.m4a", BytesIO(b"m4a"), "audio/x-m4a")},
+        files={"audio_file": ("voice.m4a", BytesIO(VALID_M4A_BYTES), "audio/x-m4a")},
         headers=headers,
     )
 
@@ -138,7 +144,7 @@ def test_upload_accepts_audio_webm(tmp_path, monkeypatch):
     response = client.post(
         f"{API_PREFIX}/entries",
         data={"question_id": str(question_id)},
-        files={"audio_file": ("voice.webm", BytesIO(b"webm"), "audio/webm")},
+        files={"audio_file": ("voice.webm", BytesIO(VALID_WEBM_BYTES), "audio/webm")},
         headers=headers,
     )
 
@@ -154,7 +160,7 @@ def test_upload_accepts_audio_3gpp(tmp_path, monkeypatch):
     response = client.post(
         f"{API_PREFIX}/entries",
         data={"question_id": str(question_id)},
-        files={"audio_file": ("voice.3gp", BytesIO(b"3gpp"), "audio/3gpp")},
+        files={"audio_file": ("voice.3gp", BytesIO(VALID_3GPP_BYTES), "audio/3gpp")},
         headers=headers,
     )
 

--- a/services/api/tests/test_entries_list.py
+++ b/services/api/tests/test_entries_list.py
@@ -11,6 +11,9 @@ from fastapi.testclient import TestClient
 API_PREFIX = "/api/v1"
 
 
+VALID_MP3_BYTES = b"ID3\x04\x00\x00\x00\x00\x00\x00payload"
+
+
 def _build_client(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
@@ -60,7 +63,7 @@ def _create_entry(client: TestClient, headers: dict[str, str]) -> dict:
     response = client.post(
         f"{API_PREFIX}/entries",
         data={"question_id": str(question_id)},
-        files={"audio_file": ("voice.mp3", BytesIO(b"audio"), "audio/mpeg")},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
         headers=headers,
     )
     assert response.status_code == 200

--- a/services/api/tests/test_upload.py
+++ b/services/api/tests/test_upload.py
@@ -1,0 +1,191 @@
+import hashlib
+from io import BytesIO
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api/v1"
+
+VALID_MP3_BYTES = b"ID3\x04\x00\x00\x00\x00\x00\x00streamed-audio"
+
+
+class GeneratedMP3Stream:
+    def __init__(self, total_size: int) -> None:
+        self._header = b"ID3\x04\x00\x00\x00\x00\x00\x00"
+        self._total_size = total_size
+        self._sent = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if self._sent >= self._total_size:
+            return b""
+        if size is None or size < 0:
+            size = 64 * 1024
+        end = min(self._total_size, self._sent + size)
+        start = self._sent
+        self._sent = end
+
+        chunk_size = end - start
+        chunk = bytearray(b"A" * chunk_size)
+        header_start = max(start, 0)
+        header_end = min(end, len(self._header))
+        if header_end > header_start:
+            for pos in range(header_start, header_end):
+                chunk[pos - start] = self._header[pos]
+        return bytes(chunk)
+
+
+def _build_client(tmp_path, monkeypatch, *, max_upload_size_mb: int = 25):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
+    monkeypatch.setenv("JWT_REFRESH_SECRET_KEY", "test-refresh-secret")
+    monkeypatch.setenv("ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("ADMIN_PASSWORD", "admin-password")
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", str(max_upload_size_mb))
+
+    import app.db
+    import app.main
+    import app.settings
+
+    app.settings.settings = app.settings.Settings()
+    app.db.settings = app.settings.settings
+    app.main.settings = app.settings.settings
+
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+    app.main.engine = app.db.engine
+
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
+    alembic_cfg.set_main_option("sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}")
+    command.upgrade(alembic_cfg, "head")
+
+    from app.models import User
+    from app.security import hash_password
+
+    with app.db.SessionLocal() as db:
+        if db.query(User).count() == 0:
+            db.add(User(email="admin@example.com", password_hash=hash_password("admin-password"), is_active=True))
+            db.commit()
+
+    return TestClient(app.main.app)
+
+
+def _auth_headers(client: TestClient) -> dict[str, str]:
+    response = client.post(
+        f"{API_PREFIX}/auth/login",
+        json={"email": "admin@example.com", "password": "admin-password"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _question_id(client: TestClient, headers: dict[str, str]) -> int:
+    question = client.get(f"{API_PREFIX}/questions/today", headers=headers)
+    assert question.status_code == 200
+    return int(question.json()["id"])
+
+
+def test_upload_rejects_payload_too_large_without_creating_entry(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch, max_upload_size_mb=1)
+    headers = _auth_headers(client)
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(_question_id(client, headers))},
+        files={"audio_file": ("voice.mp3", GeneratedMP3Stream(total_size=1024 * 1024 + 1), "audio/mpeg")},
+        headers=headers,
+    )
+
+    assert response.status_code == 413
+    assert response.json() == {
+        "error": {
+            "code": "payload_too_large",
+            "message": "Audio file exceeds upload size limit",
+        }
+    }
+
+    listed = client.get(f"{API_PREFIX}/entries", headers=headers)
+    assert listed.status_code == 200
+    assert listed.json()["items"] == []
+
+
+def test_upload_persists_stream_sha256(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(_question_id(client, headers))},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    entry_id = response.json()["id"]
+
+    import app.db
+    from app.models import Entry
+
+    with app.db.SessionLocal() as db:
+        stored = db.get(Entry, entry_id)
+        assert stored is not None
+        assert stored.audio_sha256 == hashlib.sha256(VALID_MP3_BYTES).hexdigest()
+        assert stored.audio_size == len(VALID_MP3_BYTES)
+        assert stored.audio_duration_ms is None
+
+
+def test_upload_rejects_invalid_extension_and_signature(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = _question_id(client, headers)
+
+    bad_extension = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        files={"audio_file": ("voice.wav", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+    assert bad_extension.status_code == 422
+    assert bad_extension.json() == {
+        "error": {
+            "code": "invalid_extension",
+            "message": "Filename extension does not match MIME type",
+        }
+    }
+
+    bad_signature = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        files={"audio_file": ("voice.mp3", BytesIO(b"NOT-MP3"), "audio/mpeg")},
+        headers=headers,
+    )
+    assert bad_signature.status_code == 422
+    assert bad_signature.json() == {
+        "error": {
+            "code": "invalid_signature",
+            "message": "Audio signature does not match MIME type",
+        }
+    }
+
+
+def test_upload_accepts_audio_mp4_extension(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+
+    mp4_bytes = b"\x00\x00\x00\x18ftypM4A \x00\x00\x00\x00"
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(_question_id(client, headers))},
+        files={"audio_file": ("voice.mp4", BytesIO(mp4_bytes), "audio/mp4")},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audio_mime"] == "audio/mp4"


### PR DESCRIPTION
### Motivation

- Support large audio uploads safely by streaming to disk, validating file signatures and enforcing size limits. 
- Persist audio metadata (SHA256 hash and duration) alongside entries for integrity checks and future use. 

### Description

- Add `app/storage.py` implementing `stream_upload_to_disk` which streams uploads in chunks, validates MIME/extension/signature, computes SHA256, enforces a max size, writes via a temp file and extracts WAV duration. 
- Update `app/main.py` to use `stream_upload_to_disk` and to populate new `audio_sha256`, `audio_size`, and `audio_duration_ms` fields when creating entries, and remove the inline `ALLOWED_MIME_TYPES` constant. 
- Update `app/models.py` to add `audio_sha256` and `audio_duration_ms` columns to the `Entry` model and add an Alembic migration `0004_entry_audio_metadata.py` to add those columns to the `entries` table. 
- Update and add tests to exercise streaming, signature/extension validation, size limits, SHA256 persistence, and MP4/3GPP/WEBM acceptance, including a new `tests/test_upload.py` and changes to existing tests to use valid sample audio signatures. 

### Testing

- Ran the `services/api` test suite via `pytest` covering `tests/test_entries.py`, `tests/test_entries_list.py`, `tests/test_acl.py`, and the new `tests/test_upload.py`. 
- Tests exercise `alembic` migrations with `command.upgrade(..., "head")` during setup and were executed as part of the test runs. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e71fd5a088330ad2e435348361d9b)