### PR TITLE
Add Docker-based end-to-end HTTP tests and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,43 @@ Exemple dans `.env.example`:
 ├── docker-compose.yml
 └── Makefile
 ```
+
+## Tests E2E (blackbox HTTP, Docker sandbox)
+
+Ces tests E2E pilotent automatiquement le stack Docker Compose sandbox (`docker-compose.yml` + `docker-compose.sandbox.yml`), appliquent les migrations, attendent le healthcheck, puis valident un flux réel (auth, upload, ACL, listing/pagination, audio, cleanup).
+
+Installer les dépendances dev:
+
+```bash
+python -m pip install -e "services/api[dev]"
+```
+
+Lancer les E2E:
+
+```bash
+python -m pytest -q services/api/tests_e2e
+```
+
+Option rapide (sans rebuild d'images):
+
+```bash
+E2E_NO_BUILD=1 python -m pytest -q services/api/tests_e2e
+```
+
+PowerShell:
+
+```powershell
+$env:E2E_NO_BUILD="1"
+python -m pytest -q services/api/tests_e2e
+```
+
+CMD:
+
+```cmd
+set E2E_NO_BUILD=1
+python -m pytest -q services/api/tests_e2e
+```
+
+Variables utiles:
+- `E2E_BASE_URL` (défaut: `http://localhost:8000`)
+- `E2E_NO_BUILD` (`1/true/yes` pour sauter `docker compose build`)

--- a/services/api/tests_e2e/conftest.py
+++ b/services/api/tests_e2e/conftest.py
@@ -1,0 +1,181 @@
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def _repo_root() -> Path:
+    # .../repo/services/api/tests_e2e/conftest.py -> parents[3] == repo
+    return Path(__file__).resolve().parents[3]
+
+
+def _upsert_env_var(env_path: Path, key: str, value: str) -> None:
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    if env_path.exists():
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+
+    out: list[str] = []
+    found = False
+    for line in lines:
+        if line.strip().startswith(f"{key}="):
+            out.append(f"{key}={value}")
+            found = True
+        else:
+            out.append(line)
+
+    if not found:
+        out.append(f"{key}={value}")
+
+    env_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+
+def _compose_cmd(repo: Path) -> list[str]:
+    # Use same compose files as the sandbox PowerShell workflow
+    return [
+        "docker",
+        "compose",
+        "-f",
+        str(repo / "docker-compose.yml"),
+        "-f",
+        str(repo / "docker-compose.sandbox.yml"),
+    ]
+
+
+def _run(repo: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    cp = subprocess.run(
+        args,
+        cwd=str(repo),
+        text=True,
+        capture_output=True,
+    )
+    if check and cp.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({cp.returncode}): {' '.join(args)}\n"
+            f"--- stdout ---\n{cp.stdout}\n"
+            f"--- stderr ---\n{cp.stderr}\n"
+        )
+    return cp
+
+
+def _wait_health(base_url: str, timeout_s: int = 60) -> None:
+    deadline = time.time() + timeout_s
+    last_err: object | None = None
+    while time.time() < deadline:
+        try:
+            r = httpx.get(f"{base_url}/api/v1/health", timeout=5.0)
+            if r.status_code == 200 and r.json().get("status") == "ok":
+                return
+        except Exception as e:  # noqa: BLE001
+            last_err = e
+        time.sleep(2)
+    raise RuntimeError(f"API never became healthy. Last error: {last_err!r}")
+
+
+def _seed_user_b(repo: Path, email: str, password: str) -> None:
+    # Run python inside api container to create/activate user_b
+    py = f"""
+from app.db import SessionLocal
+from app.models import User
+from app.security import hash_password
+
+email = {email!r}.lower()
+pwd = {password!r}
+
+db = SessionLocal()
+try:
+    u = db.query(User).filter(User.email == email).first()
+    hashed = hash_password(pwd)
+    if u:
+        u.is_active = True
+        u.password_hash = hashed
+        db.commit()
+        print("user_b updated")
+    else:
+        db.add(User(email=email, is_active=True, password_hash=hashed))
+        db.commit()
+        print("user_b created")
+finally:
+    db.close()
+"""
+    cmd = _compose_cmd(repo) + ["exec", "-T", "api", "python", "-c", py]
+    _run(repo, cmd, check=True)
+
+
+@pytest.fixture(scope="session")
+def e2e_base_url() -> str:
+    # Allow override for non-default ports
+    return os.environ.get("E2E_BASE_URL", "http://localhost:8000")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def e2e_stack(e2e_base_url: str):
+    """
+    Session-scoped: bring stack up once for all E2E tests, tear down at end.
+    """
+    repo = _repo_root()
+
+    # Ensure .env has required runtime config
+    env_path = repo / ".env"
+    _upsert_env_var(env_path, "APP_ENV", "development")
+    _upsert_env_var(env_path, "JWT_SECRET_KEY", uuid.uuid4().hex)
+    _upsert_env_var(env_path, "JWT_REFRESH_SECRET_KEY", uuid.uuid4().hex)
+    _upsert_env_var(env_path, "ADMIN_EMAIL", "admin@example.com")
+    _upsert_env_var(env_path, "ADMIN_PASSWORD", "admin-password")
+
+    if shutil.which("docker") is None:
+        pytest.skip("docker not found in PATH; skipping E2E tests")
+
+    cp = subprocess.run(["docker", "info"], text=True, capture_output=True)
+    if cp.returncode != 0:
+        pytest.skip("docker daemon not running; start Docker Desktop to run E2E tests")
+
+    # Clean start
+    _run(repo, _compose_cmd(repo) + ["down"], check=False)
+
+    # Reset sandbox dir (best effort; avoids state leakage across runs)
+    sandbox_dir = repo / "data_sandbox"
+    if sandbox_dir.exists():
+        try:
+            shutil.rmtree(sandbox_dir)
+        except Exception:
+            # Windows can lock directories; best-effort file cleanup
+            for p in sandbox_dir.rglob("*"):
+                try:
+                    if p.is_file():
+                        p.unlink(missing_ok=True)
+                except Exception:
+                    pass
+    (sandbox_dir / "audio").mkdir(parents=True, exist_ok=True)
+
+    # Optional build (can be skipped for speed)
+    no_build = os.environ.get("E2E_NO_BUILD", "").lower() in {"1", "true", "yes"}
+    if not no_build:
+        _run(repo, _compose_cmd(repo) + ["build"], check=True)
+
+    # Migrate before up
+    _run(
+        repo,
+        _compose_cmd(repo)
+        + ["run", "--rm", "--no-deps", "api", "alembic", "upgrade", "head"],
+        check=True,
+    )
+
+    # Up
+    _run(repo, _compose_cmd(repo) + ["up", "-d", "--force-recreate"], check=True)
+
+    # Wait API
+    _wait_health(e2e_base_url, timeout_s=60)
+
+    # Seed user_b (for ACL tests)
+    _seed_user_b(repo, "user_b@example.com", "password-b")
+
+    yield
+
+    # Tear down
+    _run(repo, _compose_cmd(repo) + ["down"], check=False)

--- a/services/api/tests_e2e/test_e2e_smoke.py
+++ b/services/api/tests_e2e/test_e2e_smoke.py
@@ -1,0 +1,113 @@
+import httpx
+
+
+def _login(base_url: str, email: str, password: str) -> dict[str, str]:
+    r = httpx.post(
+        f"{base_url}/api/v1/auth/login",
+        json={"email": email, "password": password},
+        timeout=10.0,
+    )
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _upload_entry(base_url: str, headers: dict[str, str], question_id: int) -> dict:
+    # Minimal MP3 signature accepted by backend (ID3...)
+    mp3_bytes = b"ID3\x04\x00\x00\x00\x00\x00\x00payload"
+    files = {"audio_file": ("voice.mp3", mp3_bytes, "audio/mpeg")}
+    data = {"question_id": str(question_id)}
+    r = httpx.post(
+        f"{base_url}/api/v1/entries",
+        headers=headers,
+        data=data,
+        files=files,
+        timeout=20.0,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_e2e_full_flow(e2e_base_url: str):
+    base = e2e_base_url
+
+    # Health
+    r = httpx.get(f"{base}/api/v1/health", timeout=5.0)
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+    # Auth required
+    assert httpx.get(f"{base}/api/v1/questions/today", timeout=5.0).status_code == 401
+    assert httpx.get(f"{base}/api/v1/entries", timeout=5.0).status_code == 401
+
+    # Login admin
+    admin_headers = _login(base, "admin@example.com", "admin-password")
+
+    # Get question
+    q = httpx.get(f"{base}/api/v1/questions/today", headers=admin_headers, timeout=10.0)
+    assert q.status_code == 200, q.text
+    qid = int(q.json()["id"])
+
+    # Create entry (upload)
+    entry = _upload_entry(base, admin_headers, qid)
+    entry_id = entry["id"]
+
+    # Audio endpoint
+    audio = httpx.get(
+        f"{base}/api/v1/entries/{entry_id}/audio",
+        headers=admin_headers,
+        timeout=10.0,
+    )
+    assert audio.status_code == 200
+
+    # Login user B (seeded by conftest)
+    user_b_headers = _login(base, "user_b@example.com", "password-b")
+
+    # ACL: user B cannot access admin entry (403)
+    for path in [f"/api/v1/entries/{entry_id}", f"/api/v1/entries/{entry_id}/audio"]:
+        rr = httpx.get(f"{base}{path}", headers=user_b_headers, timeout=10.0)
+        assert rr.status_code == 403, rr.text
+
+    rr = httpx.delete(
+        f"{base}/api/v1/entries/{entry_id}", headers=user_b_headers, timeout=10.0
+    )
+    assert rr.status_code == 403, rr.text
+
+    # Missing stays 404
+    missing = "00000000-0000-0000-0000-000000000000"
+    assert (
+        httpx.get(
+            f"{base}/api/v1/entries/{missing}", headers=user_b_headers, timeout=10.0
+        ).status_code
+        == 404
+    )
+    assert (
+        httpx.get(
+            f"{base}/api/v1/entries/{missing}/audio",
+            headers=user_b_headers,
+            timeout=10.0,
+        ).status_code
+        == 404
+    )
+    assert (
+        httpx.delete(
+            f"{base}/api/v1/entries/{missing}", headers=user_b_headers, timeout=10.0
+        ).status_code
+        == 404
+    )
+
+    # Listing wrapper + clamp basic
+    lst = httpx.get(f"{base}/api/v1/entries", headers=admin_headers, timeout=10.0).json()
+    assert "items" in lst and "limit" in lst and "offset" in lst and "next_offset" in lst
+
+    clamped = httpx.get(
+        f"{base}/api/v1/entries?limit=999", headers=admin_headers, timeout=10.0
+    ).json()
+    assert clamped["limit"] == 200
+
+    # Cleanup
+    d = httpx.delete(f"{base}/api/v1/entries/{entry_id}", headers=admin_headers, timeout=10.0)
+    assert d.status_code == 200, d.text
+
+    lst2 = httpx.get(f"{base}/api/v1/entries", headers=admin_headers, timeout=10.0).json()
+    assert lst2["items"] == []


### PR DESCRIPTION
### Motivation
- Provide blackbox end-to-end coverage for the API to validate auth, upload, ACL, listing/pagination, audio endpoints and cleanup in a Docker sandbox.

### Description
- Add `services/api/tests_e2e/conftest.py` to manage the Docker Compose sandbox lifecycle, run migrations, wait for health, seed a secondary user and tear down the stack.
- Add `services/api/tests_e2e/test_e2e_smoke.py` which exercises a full happy-path flow including health, login, question fetch, entry upload, audio download, ACL checks and cleanup.
- Extend `README.md` with a new "Tests E2E (blackbox HTTP, Docker sandbox)" section documenting dependencies, invocation commands, and useful environment variables like `E2E_BASE_URL` and `E2E_NO_BUILD`.

### Testing
- No automated CI tests were executed as part of this change in the repository; the E2E suite requires Docker to run locally and is enabled by the added fixtures.
- To run locally, use `python -m pip install -e "services/api[dev]"` and then `python -m pytest -q services/api/tests_e2e` (or `E2E_NO_BUILD=1 python -m pytest -q services/api/tests_e2e` to skip image rebuild).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed0b2257083309663b69a37db9ab8)