### PR TITLE
Add HTTP security headers, CORS & TrustedHost support with settings and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Exemple dans `.env.example`:
 - `APP_ENV`: environnement applicatif (`development` par défaut)
 - `DATA_DIR`: dossier de données local (`./data`)
 - `API_BASE_URL`: URL de l'API consommée par Streamlit (`http://api:8000` dans Docker)
+- `ALLOWED_ORIGINS`: liste CSV des origines CORS autorisées (défaut dev: `http://localhost:3000,http://localhost:8501,http://localhost:8000`)
+- `ALLOWED_HOSTS`: liste CSV des hosts HTTP autorisés (`localhost,127.0.0.1,testserver` par défaut)
+- `ENABLE_HSTS`: active l'en-tête `Strict-Transport-Security` (`false` par défaut)
+- `HSTS_MAX_AGE`: valeur `max-age` pour HSTS (défaut: `31536000`)
 
 ## Structure du projet
 

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -15,6 +15,8 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy import inspect, select
 from sqlalchemy.orm import Session
@@ -30,6 +32,39 @@ from app.storage import ALLOWED_MIME_TYPES, stream_upload_to_disk
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 logger = logging.getLogger(__name__)
 api_v1_router = APIRouter(prefix="/api/v1")
+
+if "*" in settings.allowed_origins:
+    raise RuntimeError("Wildcard origin '*' is not allowed in ALLOWED_ORIGINS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
+)
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
+
+
+@app.middleware("http")
+async def security_headers_middleware(request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+    response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+    response.headers["Cross-Origin-Resource-Policy"] = "same-site"
+    if request.url.path.startswith("/api/"):
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'none'; frame-ancestors 'none'"
+        )
+    if settings.enable_hsts:
+        response.headers["Strict-Transport-Security"] = (
+            f"max-age={settings.hsts_max_age}; includeSubDomains"
+        )
+    return response
+
 
 SEED_QUESTIONS: list[tuple[str, str]] = [
     ("Quel moment t'a fait sourire aujourd'hui ?", "gratitude"),

--- a/services/api/app/settings.py
+++ b/services/api/app/settings.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import Annotated
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -19,6 +21,19 @@ class Settings(BaseSettings):
     admin_email: str | None = None
     admin_password: str | None = None
 
+    allowed_origins: Annotated[list[str], NoDecode] = [
+        "http://localhost:3000",
+        "http://localhost:8501",
+        "http://localhost:8000",
+    ]
+    allowed_hosts: Annotated[list[str], NoDecode] = [
+        "localhost",
+        "127.0.0.1",
+        "testserver",
+    ]
+    enable_hsts: bool = False
+    hsts_max_age: int = 31536000
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
@@ -32,6 +47,13 @@ class Settings(BaseSettings):
     @property
     def audio_dir(self) -> Path:
         return self.data_dir / "audio"
+
+    @field_validator("allowed_origins", "allowed_hosts", mode="before")
+    @classmethod
+    def _parse_csv_list(cls, value: list[str] | str) -> list[str]:
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return value
 
 
 settings = Settings()

--- a/services/api/tests/test_http_security.py
+++ b/services/api/tests/test_http_security.py
@@ -1,0 +1,85 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api/v1"
+
+
+def _build_client(tmp_path, monkeypatch) -> TestClient:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8501")
+    monkeypatch.setenv("ALLOWED_HOSTS", "localhost,127.0.0.1,testserver")
+
+    import app.db
+    import app.main
+    import app.settings
+
+    importlib.reload(app.settings)
+
+    app.db.settings = app.settings.settings
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+
+    importlib.reload(app.main)
+    app.main.settings = app.settings.settings
+    app.main.engine = app.db.engine
+
+    return TestClient(app.main.app)
+
+
+def test_security_headers_present_on_health(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.get(f"{API_PREFIX}/health")
+
+    assert response.status_code == 200
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "no-referrer"
+    assert (
+        response.headers["Permissions-Policy"]
+        == "geolocation=(), microphone=(), camera=()"
+    )
+    assert response.headers["Cross-Origin-Opener-Policy"] == "same-origin"
+    assert response.headers["Cross-Origin-Resource-Policy"] == "same-site"
+
+
+def test_trusted_host_rejects_unknown_host(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.get(f"{API_PREFIX}/health", headers={"Host": "evil.com"})
+
+    assert response.status_code == 400
+
+
+def test_cors_allows_configured_origin(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.options(
+        f"{API_PREFIX}/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code in {200, 204}
+    assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:3000"
+
+
+def test_cors_rejects_unconfigured_origin(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.options(
+        f"{API_PREFIX}/health",
+        headers={
+            "Origin": "http://evil.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.headers.get("Access-Control-Allow-Origin") != "http://evil.com"


### PR DESCRIPTION
### Motivation
- Harden the API by adding common HTTP security headers, CORS and trusted host filtering to reduce attack surface.
- Provide runtime configuration for allowed origins/hosts and HSTS via environment variables to support different deployments.
- Ensure the new behavior is covered by automated tests that validate headers, CORS and host filtering.

### Description
- Added `CORSMiddleware` and `TrustedHostMiddleware` to the FastAPI app and disallow wildcard origin `"*"` in `ALLOWED_ORIGINS` by raising a `RuntimeError` when present.
- Added an HTTP middleware `security_headers_middleware` that sets `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`, a `Content-Security-Policy` for `/api/` paths, and conditional `Strict-Transport-Security` when `ENABLE_HSTS` is enabled.
- Extended settings in `settings.py` with `allowed_origins`, `allowed_hosts`, `enable_hsts`, and `hsts_max_age`, parsed from CSV environment variables using a `@field_validator` and declared with `Annotated`/`NoDecode` to prevent decoding semantics.
- Updated `README.md` to document the new environment variables `ALLOWED_ORIGINS`, `ALLOWED_HOSTS`, `ENABLE_HSTS`, and `HSTS_MAX_AGE`.
- Added `services/api/tests/test_http_security.py` which exercises security headers, trusted host rejection, and CORS allow/deny behavior.

### Testing
- Ran `pytest` under `services/api` which executed the new `test_http_security.py` tests and existing suite; tests passed.
- The security tests validate presence of expected headers on `GET /api/v1/health`, trusted host rejection for unknown `Host` header, and CORS preflight allow/reject behavior for configured and unconfigured origins, respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a01fd79b808330883553782b05999c)