### PR TITLE
Add request-id middleware with JSON logging and system health/readiness endpoints

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -22,8 +22,10 @@ from sqlalchemy import inspect, select
 from sqlalchemy.orm import Session
 
 from app.db import engine, get_db
+from app.middleware.request_id import RequestIdMiddleware, configure_json_logging
 from app.models import Entry, Question, User
 from app.routes.auth import router as auth_router
+from app.routes.system import router as system_router
 from app.schemas import EntriesListResponse, EntryOut, QuestionOut
 from app.security import get_current_user, hash_password
 from app.settings import settings
@@ -44,6 +46,7 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type"],
 )
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
+app.add_middleware(RequestIdMiddleware)
 
 
 @app.middleware("http")
@@ -82,6 +85,7 @@ SEED_QUESTIONS: list[tuple[str, str]] = [
 
 @app.on_event("startup")
 def startup() -> None:
+    configure_json_logging()
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     settings.audio_dir.mkdir(parents=True, exist_ok=True)
     if not inspect(engine).has_table("entries"):
@@ -124,11 +128,6 @@ def generic_exception_handler(_, __: Exception) -> JSONResponse:
         status_code=500,
         content={"error": {"code": "500", "message": "Internal server error"}},
     )
-
-
-@api_v1_router.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok"}
 
 
 @api_v1_router.get("/version")
@@ -326,4 +325,5 @@ def delete_entry(
 
 
 api_v1_router.include_router(auth_router)
+api_v1_router.include_router(system_router)
 app.include_router(api_v1_router)

--- a/services/api/app/middleware/request_id.py
+++ b/services/api/app/middleware/request_id.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+import uuid
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+STANDARD_LOG_RECORD_ATTRS: set[str] = {
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+    "message",
+}
+
+
+def get_request_id() -> str | None:
+    return _request_id_var.get()
+
+
+def _normalize_request_id(value: str | None) -> str | None:
+    if not value:
+        return None
+    v = value.strip().replace("\r", "").replace("\n", "")
+    if not v:
+        return None
+    if len(v) > 128:
+        v = v[:128]
+    if not _REQUEST_ID_RE.fullmatch(v):
+        return None
+    return v
+
+
+class RequestIdLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id()
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+            "request_id": getattr(record, "request_id", None),
+        }
+
+        items: Iterable[tuple[str, Any]] = record.__dict__.items()
+        extras = {
+            k: v
+            for k, v in items
+            if k not in STANDARD_LOG_RECORD_ATTRS and not k.startswith("_")
+        }
+        payload.update(extras)
+
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def configure_json_logging(level: int = logging.INFO) -> None:
+    base = logging.getLogger("app")
+    base.setLevel(level)
+
+    if base.handlers:
+        return
+
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    handler.addFilter(RequestIdLogFilter())
+    handler.setFormatter(JsonFormatter())
+
+    base.addHandler(handler)
+    base.propagate = False
+
+
+class RequestIdMiddleware:
+    header_name = "X-Request-Id"
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self.logger = logging.getLogger("app.http")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        incoming = headers.get(b"x-request-id", b"").decode("latin-1")
+        rid = _normalize_request_id(incoming) or uuid.uuid4().hex
+
+        token = _request_id_var.set(rid)
+        start = time.perf_counter()
+        status_code = 500
+
+        raw_query = scope.get("query_string", b"").decode("latin-1")
+        query_keys = sorted(
+            {
+                chunk.split("=", 1)[0]
+                for chunk in raw_query.split("&")
+                if chunk and chunk.split("=", 1)[0]
+            }
+        )
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+                mutable_headers = MutableHeaders(scope=message)
+                mutable_headers[self.header_name] = rid
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            duration_ms = int((time.perf_counter() - start) * 1000)
+            self.logger.info(
+                "request",
+                extra={
+                    "method": scope.get("method", ""),
+                    "path": scope.get("path", ""),
+                    "query_keys": query_keys,
+                    "status_code": status_code,
+                    "duration_ms": duration_ms,
+                },
+            )
+            _request_id_var.reset(token)

--- a/services/api/app/routes/system.py
+++ b/services/api/app/routes/system.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.settings import settings
+
+router = APIRouter(tags=["system"])
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/readyz")
+def readyz(db: Session = Depends(get_db)) -> JSONResponse:
+    checks: dict[str, dict[str, object]] = {}
+
+    # DB check
+    try:
+        db.execute(text("SELECT 1"))
+        checks["db"] = {"ok": True}
+    except Exception as e:  # noqa: BLE001
+        checks["db"] = {"ok": False, "error": str(e)}
+
+    # Audio dir check: exists, is dir, writable
+    audio_dir = settings.audio_dir
+    try:
+        if audio_dir.exists() and not audio_dir.is_dir():
+            raise RuntimeError(f"{audio_dir} exists but is not a directory")
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        probe = audio_dir / f".readyz_{uuid.uuid4().hex}.tmp"
+        probe.write_bytes(b"ok")
+        probe.unlink(missing_ok=True)
+        checks["audio_dir"] = {"ok": True, "path": str(audio_dir)}
+    except Exception as e:  # noqa: BLE001
+        checks["audio_dir"] = {"ok": False, "path": str(audio_dir), "error": str(e)}
+
+    ok = all(v.get("ok") is True for v in checks.values())
+    status = "ok" if ok else "fail"
+    code = 200 if ok else 503
+    return JSONResponse(status_code=code, content={"status": status, "checks": checks})

--- a/services/api/tests/test_system.py
+++ b/services/api/tests/test_system.py
@@ -1,0 +1,81 @@
+import importlib
+import re
+import shutil
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+API_PREFIX = "/api/v1"
+
+
+def _build_client(tmp_path: Path, monkeypatch) -> TestClient:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8501")
+    monkeypatch.setenv("ALLOWED_HOSTS", "localhost,127.0.0.1,testserver")
+
+    import app.db
+    import app.main
+    import app.routes.system
+    import app.settings
+
+    importlib.reload(app.settings)
+    importlib.reload(app.routes.system)
+
+    if hasattr(app.db, "create_engine"):
+        app.db.settings = app.settings.settings
+        app.db.engine.dispose()
+        app.db.engine = app.db.create_engine(
+            f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+            connect_args={"check_same_thread": False},
+        )
+        app.db.SessionLocal.configure(bind=app.db.engine)
+
+    importlib.reload(app.main)
+    app.main.settings = app.settings.settings
+    if hasattr(app.db, "engine"):
+        app.main.engine = app.db.engine
+
+    return TestClient(app.main.app)
+
+
+def test_health_has_request_id_header(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    r = client.get(f"{API_PREFIX}/health")
+    assert r.status_code == 200
+    rid = r.headers.get("X-Request-Id")
+    assert rid is not None
+    assert len(rid) >= 8
+
+
+def test_health_ignores_invalid_request_id_header(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    r = client.get(f"{API_PREFIX}/health", headers={"X-Request-Id": "bad value!"})
+    assert r.status_code == 200
+    rid = r.headers.get("X-Request-Id")
+    assert rid is not None
+    assert re.fullmatch(r"[0-9a-f]{32}", rid)
+
+
+def test_readyz_ok(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    r = client.get(f"{API_PREFIX}/readyz")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "ok"
+
+
+def test_readyz_fails_if_audio_dir_becomes_file(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+
+    import app.routes.system
+
+    audio_path = app.routes.system.settings.audio_dir
+    if audio_path.exists() and audio_path.is_dir():
+        shutil.rmtree(audio_path)
+    audio_path.write_text("not a dir", encoding="utf-8")
+
+    r = client.get(f"{API_PREFIX}/readyz")
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["status"] == "fail"
+    assert body["checks"]["audio_dir"]["ok"] is False


### PR DESCRIPTION
### Motivation
- Provide end-to-end request tracing via an `X-Request-Id` header and include that id in logs for better observability. 
- Centralize system-level endpoints for health and readiness checks and ensure they validate DB and storage availability.

### Description
- Add `app/middleware/request_id.py` implementing `RequestIdMiddleware`, `RequestIdLogFilter`, `JsonFormatter`, `get_request_id()`, and `configure_json_logging()` to inject `X-Request-Id` and emit structured JSON logs. 
- Wire the middleware into the application by calling `app.add_middleware(RequestIdMiddleware)` and invoking `configure_json_logging()` on startup. 
- Move the simple health endpoint into a new router `app/routes/system.py` and add a `/readyz` endpoint that verifies the database and audio directory writability. 
- Include the new `system` router in the API and remove the previous inline health handler from `main.py`. 

### Testing
- Added `services/api/tests/test_system.py` with tests for request id header behavior and readiness checks, and ran `pytest services/api/tests/test_system.py`, which passed. 
- Exercised the `/readyz` failure case by making the audio directory a file, and the test correctly returned HTTP `503` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04efaf6fc83309e498ea1a73b32e8)