### PR TITLE
Add backup/restore scripts, docs and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup up down logs
+.PHONY: setup up down logs backup restore
 
 setup:
 	cp -n .env.example .env || true
@@ -11,3 +11,13 @@ down:
 
 logs:
 	docker compose logs -f
+
+backup:
+	./scripts/backup.sh
+
+restore:
+	@if [ -z "$(BACKUP)" ]; then \
+		echo "Usage: make restore BACKUP=backups/echo_backup_YYYYmmdd_HHMMSSZ.tar.gz"; \
+		exit 1; \
+	fi
+	./scripts/restore.sh "$(BACKUP)"

--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ Exemple dans `.env.example`:
 - `ENABLE_HSTS`: active l'en-tête `Strict-Transport-Security` (`false` par défaut)
 - `HSTS_MAX_AGE`: valeur `max-age` pour HSTS (défaut: `31536000`)
 
+## Backups & restore
+
+Voir la documentation dédiée: [`docs/backup_restore.md`](docs/backup_restore.md).
+
 ## Structure du projet
 
 ```text

--- a/docs/backup_restore.md
+++ b/docs/backup_restore.md
@@ -1,0 +1,120 @@
+# Backup & restore (SQLite + audio)
+
+Ce projet fournit deux scripts Bash pour sauvegarder et restaurer les données persistées (`echo.db` + dossier `audio/`) de façon sûre.
+
+- Backup: `scripts/backup.sh`
+- Restore: `scripts/restore.sh`
+
+## Recommandations
+
+- **Idéalement**, stoppez les conteneurs pendant un backup (`docker compose down`) pour éviter toute activité concurrente.
+- Si ce n'est pas possible, le script utilise `sqlite3 .backup` quand `sqlite3` est disponible, ce qui produit un snapshot SQLite cohérent.
+
+## Créer un backup
+
+Commande par défaut (sortie dans `./backups`):
+
+```bash
+scripts/backup.sh
+```
+
+Exemple de fichier généré:
+
+```text
+backups/echo_backup_YYYYmmdd_HHMMSSZ.tar.gz
+```
+
+Options utiles:
+
+```bash
+scripts/backup.sh --data-dir ./data
+scripts/backup.sh --out-dir ./backups
+scripts/backup.sh --db ./data/echo.db --audio-dir ./data/audio
+scripts/backup.sh --no-compress
+```
+
+Contenu de l'archive:
+
+- `manifest.json` (timestamp, chemins source, versions outils)
+- `db/echo.db` (snapshot)
+- `audio/` (copie complète)
+
+## Restaurer un backup
+
+Usage:
+
+```bash
+scripts/restore.sh <backup_tar_or_tar_gz> [--dest-dir <path>]
+```
+
+Exemples:
+
+```bash
+scripts/restore.sh backups/echo_backup_20260101_120000Z.tar.gz
+scripts/restore.sh backups/echo_backup_20260101_120000Z.tar.gz --dest-dir ./data_restore
+```
+
+Comportement sécurité:
+
+- La restauration se fait **toujours** dans un sous-dossier de `data_restore/` (ou du `--dest-dir` fourni).
+- Le script n'écrase pas silencieusement:
+  - En TTY: confirmation demandée avant overwrite.
+  - Hors TTY (CI/script): échec explicite si le dossier cible existe.
+
+Après extraction, le script affiche:
+
+- chemin de la DB restaurée
+- chemin du dossier audio restauré
+- commande à utiliser pour lancer l'app avec `DATA_DIR` pointant vers le restore
+
+## Procédure de test manuelle (recommandée)
+
+1. Créer un backup:
+
+```bash
+scripts/backup.sh
+```
+
+Attendu: un fichier `backups/echo_backup_*.tar.gz` est créé.
+
+2. Restaurer ce backup:
+
+```bash
+scripts/restore.sh backups/echo_backup_*.tar.gz
+```
+
+Attendu: un dossier `data_restore/<nom_archive>/` est créé avec:
+
+- `echo.db`
+- `audio/`
+- `manifest.json`
+
+3. Lancer l'API sur les données restaurées.
+
+En local (depuis `services/api`):
+
+```bash
+DATA_DIR="$(pwd)/../../data_restore/<nom_archive>" uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Ou via Docker Compose:
+
+```bash
+DATA_DIR="$(pwd)/data_restore/<nom_archive>" docker compose up --build
+```
+
+4. Vérifier l'état et les médias:
+
+```bash
+curl -i http://localhost:8000/api/v1/readyz
+```
+
+Attendu: statut `200`.
+
+Puis vérifier qu'au moins un fichier audio existe (si votre backup contenait des audios):
+
+```bash
+find data_restore/<nom_archive>/audio -type f | head -n 5
+```
+
+Attendu: au moins un chemin listé.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[backup] %s\n' "$*"
+}
+
+die() {
+  printf '[backup] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/backup.sh [options]
+
+Options:
+  --data-dir <path>   Data directory (default: $DATA_DIR or <repo_root>/data)
+  --out-dir <path>    Backup output directory (default: <repo_root>/backups)
+  --db <path>         SQLite DB path (default: <data-dir>/echo.db)
+  --audio-dir <path>  Audio directory path (default: <data-dir>/audio)
+  --no-compress       Produce a .tar bundle instead of .tar.gz
+  -h, --help          Show this help message
+USAGE
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+  repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+data_dir="${DATA_DIR:-$repo_root/data}"
+out_dir="$repo_root/backups"
+db_path=""
+audio_dir=""
+compress=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --data-dir)
+      [[ $# -ge 2 ]] || die "Missing value for --data-dir"
+      data_dir="$2"
+      shift 2
+      ;;
+    --out-dir)
+      [[ $# -ge 2 ]] || die "Missing value for --out-dir"
+      out_dir="$2"
+      shift 2
+      ;;
+    --db)
+      [[ $# -ge 2 ]] || die "Missing value for --db"
+      db_path="$2"
+      shift 2
+      ;;
+    --audio-dir)
+      [[ $# -ge 2 ]] || die "Missing value for --audio-dir"
+      audio_dir="$2"
+      shift 2
+      ;;
+    --no-compress)
+      compress=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$db_path" ]]; then
+  db_path="$data_dir/echo.db"
+fi
+if [[ -z "$audio_dir" ]]; then
+  audio_dir="$data_dir/audio"
+fi
+
+[[ -f "$db_path" ]] || die "Database file not found: $db_path"
+[[ -d "$audio_dir" ]] || die "Audio directory not found: $audio_dir"
+mkdir -p "$out_dir"
+
+timestamp="$(date -u +%Y%m%d_%H%M%SZ)"
+ext="tar.gz"
+if [[ "$compress" -eq 0 ]]; then
+  ext="tar"
+fi
+bundle_path="$out_dir/echo_backup_${timestamp}.${ext}"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/db" "$tmp_dir/audio"
+
+if command -v sqlite3 >/dev/null 2>&1; then
+  log "Creating SQLite snapshot with sqlite3 .backup"
+  sqlite3 "$db_path" ".backup '$tmp_dir/db/echo.db'"
+else
+  log "sqlite3 not found; falling back to file copy"
+  cp "$db_path" "$tmp_dir/db/echo.db"
+fi
+
+log "Copying audio directory"
+cp -a "$audio_dir/." "$tmp_dir/audio/"
+
+created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+sqlite_version="unavailable"
+if command -v sqlite3 >/dev/null 2>&1; then
+  sqlite_version="$(sqlite3 --version 2>/dev/null | awk '{print $1}')"
+fi
+tar_version="$(tar --version 2>/dev/null | head -n 1 || echo unavailable)"
+bash_version="${BASH_VERSION:-unavailable}"
+
+cat > "$tmp_dir/manifest.json" <<MANIFEST
+{
+  "created_at_utc": "$(json_escape "$created_at")",
+  "db_path": "$(json_escape "$db_path")",
+  "audio_dir": "$(json_escape "$audio_dir")",
+  "tool_versions": {
+    "bash": "$(json_escape "$bash_version")",
+    "sqlite3": "$(json_escape "$sqlite_version")",
+    "tar": "$(json_escape "$tar_version")"
+  }
+}
+MANIFEST
+
+log "Writing bundle: $bundle_path"
+if [[ "$compress" -eq 1 ]]; then
+  tar -C "$tmp_dir" -czf "$bundle_path" manifest.json db audio
+else
+  tar -C "$tmp_dir" -cf "$bundle_path" manifest.json db audio
+fi
+
+log "Backup complete"
+log "Bundle available at: $bundle_path"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[restore] %s\n' "$*"
+}
+
+die() {
+  printf '[restore] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/restore.sh <backup_tar_or_tar_gz> [--dest-dir <path>]
+
+Options:
+  --dest-dir <path>  Base restore directory (default: <repo_root>/data_restore)
+  -h, --help         Show this help message
+USAGE
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+  repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+dest_root="$repo_root/data_restore"
+backup_file=""
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dest-dir)
+      [[ $# -ge 2 ]] || die "Missing value for --dest-dir"
+      dest_root="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -* )
+      die "Unknown option: $1"
+      ;;
+    *)
+      if [[ -n "$backup_file" ]]; then
+        die "Only one backup file may be provided"
+      fi
+      backup_file="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$backup_file" ]] || die "Backup archive is required"
+[[ -f "$backup_file" ]] || die "Backup archive not found: $backup_file"
+
+archive_name="$(basename "$backup_file")"
+archive_base="$archive_name"
+archive_base="${archive_base%.tar.gz}"
+archive_base="${archive_base%.tgz}"
+archive_base="${archive_base%.tar}"
+target_dir="$dest_root/$archive_base"
+
+mkdir -p "$dest_root"
+
+if [[ -e "$target_dir" ]]; then
+  if [[ -t 0 ]]; then
+    read -r -p "Target exists ($target_dir). Overwrite? [y/N] " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+      die "Restore cancelled by user"
+    fi
+    rm -rf "$target_dir"
+  else
+    die "Target already exists in non-interactive mode: $target_dir"
+  fi
+fi
+
+mkdir -p "$target_dir"
+
+tar -tf "$backup_file" | awk '
+  /^\// {bad=1}
+  /(^|\/)\.\.(\/|$)/ {bad=1}
+  END {exit bad}
+' || die "Archive contains unsafe paths (absolute or ..)"
+
+log "Extracting archive into: $target_dir"
+tar --no-same-owner --no-same-permissions -xf "$backup_file" -C "$target_dir"
+
+restored_db_snapshot="$target_dir/db/echo.db"
+restored_audio_dir="$target_dir/audio"
+[[ -f "$restored_db_snapshot" ]] || die "Missing DB snapshot in archive (expected db/echo.db)"
+[[ -d "$restored_audio_dir" ]] || die "Missing audio directory in archive (expected audio/)"
+
+cp "$restored_db_snapshot" "$target_dir/echo.db"
+
+if [[ -f "$target_dir/manifest.json" ]]; then
+  log "Manifest summary:"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY' "$target_dir/manifest.json"
+import json
+import pathlib
+import sys
+
+manifest = pathlib.Path(sys.argv[1])
+try:
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"  - Unable to parse manifest.json: {exc}")
+    sys.exit(0)
+
+print(f"  - created_at_utc: {data.get('created_at_utc', 'n/a')}")
+print(f"  - db_path: {data.get('db_path', 'n/a')}")
+print(f"  - audio_dir: {data.get('audio_dir', 'n/a')}")
+PY
+  else
+    sed 's/^/  /' "$target_dir/manifest.json"
+  fi
+fi
+
+log "Restore complete"
+log "DB restored at: $target_dir/echo.db"
+log "Audio restored at: $target_dir/audio"
+log "Run app against this restore with:"
+log "  DATA_DIR='$target_dir' docker compose up"


### PR DESCRIPTION
### Motivation

- Provide a simple, safe way to snapshot and restore the persisted data (SQLite DB + audio files) for development and recovery.
- Expose convenient `make` targets to run backups and restores from the project root.

### Description

- Add executable scripts `scripts/backup.sh` and `scripts/restore.sh` implementing backup creation (with optional compression and `sqlite3 .backup` snapshot when available) and safe restore with manifest handling and path-safety checks.
- Add documentation `docs/backup_restore.md` describing usage, options, safety behavior, and a recommended manual test procedure.
- Update `README.md` to reference the new backups & restore documentation and explain the feature briefly.
- Update `Makefile` to add `backup` and `restore` phony targets where `backup` runs `./scripts/backup.sh` and `restore` runs `./scripts/restore.sh` with a required `BACKUP` variable check.

### Testing

- No automated tests were added for the new scripts as part of this change.
- Manual usage and verification steps are documented in `docs/backup_restore.md` for local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0639cc8b08330bd6025787e91ea12)