### PR TITLE
Add local Docker E2E system tests and use dedicated compose env file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: ruff format --check .
 
       - name: Pytest with coverage threshold
-        run: pytest -q --cov=app --cov-report=term-missing --cov-fail-under=70
+        run: pytest -q -m "not e2e" --cov=app --cov-report=term-missing --cov-fail-under=70

--- a/services/api/pytest.ini
+++ b/services/api/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    e2e: end-to-end tests requiring docker compose and RUN_E2E=1

--- a/services/api/tests_e2e/conftest.py
+++ b/services/api/tests_e2e/conftest.py
@@ -137,6 +137,10 @@ def e2e_stack(e2e_base_url: str):
     """
     Session-scoped: bring stack up once for all E2E tests, tear down at end.
     """
+    run_e2e = os.environ.get("RUN_E2E", "").strip().lower() in {"1", "true", "yes"}
+    if not run_e2e:
+        pytest.skip("E2E disabled by default. Set RUN_E2E=1 to enable Docker E2E tests.")
+
     repo = _repo_root()
 
     if shutil.which("docker") is None:

--- a/services/api/tests_e2e/test_e2e_smoke.py
+++ b/services/api/tests_e2e/test_e2e_smoke.py
@@ -1,4 +1,7 @@
 import httpx
+import pytest
+
+pytestmark = pytest.mark.e2e
 
 
 def _login(base_url: str, email: str, password: str) -> dict[str, str]:

--- a/services/api/tests_e2e/test_e2e_system.py
+++ b/services/api/tests_e2e/test_e2e_system.py
@@ -1,6 +1,9 @@
 import re
 
 import httpx
+import pytest
+
+pytestmark = pytest.mark.e2e
 
 
 def _assert_request_id(value: str) -> None:


### PR DESCRIPTION
### Motivation
- Add system-level E2E checks for the new `/api/v1/readyz` endpoint and validate the `X-Request-Id` header on responses.
- Avoid mutating the repository `.env` during E2E runs by writing runtime secrets to a disposable file under `data_sandbox`.
- Ensure the test stack waits for real readiness (`/api/v1/readyz`) before running tests to reduce flakes.

### Description
- Added `services/api/tests_e2e/test_e2e_system.py` which tests `/api/v1/health` and `/api/v1/readyz`, asserts `status == "ok

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06fa51994833091b889f58e006140)