### PR TITLE
style: ruff format tests_e2e/conftest.py

### DIFF
--- a/services/api/tests_e2e/conftest.py
+++ b/services/api/tests_e2e/conftest.py
@@ -139,7 +139,9 @@ def e2e_stack(e2e_base_url: str):
     """
     run_e2e = os.environ.get("RUN_E2E", "").strip().lower() in {"1", "true", "yes"}
     if not run_e2e:
-        pytest.skip("E2E disabled by default. Set RUN_E2E=1 to enable Docker E2E tests.")
+        pytest.skip(
+            "E2E disabled by default. Set RUN_E2E=1 to enable Docker E2E tests."
+        )
 
     repo = _repo_root()
 


### PR DESCRIPTION
### Motivation
- Corriger l'échec CI causé par `ruff format --check .` qui indiquait que `tests_e2e/conftest.py` devait être reformatté en appliquant le formatteur Ruff.

### Description
- Exécution de `ruff format tests_e2e/conftest.py` depuis `services/api`, ce qui a reformatté l'appel `pytest.skip(...)` en plusieurs lignes; seul le fichier `services/api/tests_e2e/conftest.py` a été modifié et la modification a été commitée (commit `bbd936e`).

### Testing
- Exécuté `cd services/api && ruff format tests_e2e/conftest.py`, qui a reformatté 1 file (succès).
- Exécuté `cd services/api && ruff format --check .` et `cd services/api && ruff check .`, les deux sont passés (`27 files already formatted` / `All checks passed!`).
- Vérifié avec `git diff services/api/tests_e2e/conftest.py` et `git status --short` que seul `services/api/tests_e2e/conftest.py` a changé, puis effectué `git add` + `git commit -m "style: ruff format tests_e2e/conftest.py"` (succès); `git push` a échoué car aucun remote n'est configuré dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09cfb14f48330b80623b129276a01)