### PR TITLE
Add entry freeze flag, API endpoint to freeze entries, migration and tests

### DIFF
--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = alembic
+script_location = %(here)s/alembic
 sqlalchemy.url = sqlite:////app/data/echo.db
 
 [loggers]

--- a/services/api/alembic/versions/0005_entry_freeze_flag.py
+++ b/services/api/alembic/versions/0005_entry_freeze_flag.py
@@ -1,0 +1,30 @@
+"""add freeze flag for entries
+
+Revision ID: 0005_entry_freeze_flag
+Revises: 0004_entry_audio_metadata
+Create Date: 2026-02-26
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0005_entry_freeze_flag"
+down_revision: Union[str, None] = "0004_entry_audio_metadata"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "entries",
+        sa.Column(
+            "is_frozen", sa.Boolean(), nullable=False, server_default=sa.text("0")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("entries", "is_frozen")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -284,6 +284,27 @@ def get_entry(
     return entry
 
 
+@api_v1_router.post("/entries/{entry_id}/freeze")
+def freeze_entry(
+    entry_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, str | bool]:
+    entry = db.get(Entry, entry_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    if entry.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403, detail={"code": "forbidden", "message": "Not allowed"}
+        )
+
+    if not entry.is_frozen:
+        entry.is_frozen = True
+        db.commit()
+
+    return {"status": "frozen", "id": entry_id, "is_frozen": True}
+
+
 @api_v1_router.get("/entries/{entry_id}/audio")
 def get_entry_audio(
     entry_id: str,
@@ -315,6 +336,11 @@ def delete_entry(
     if entry.user_id != current_user.id:
         raise HTTPException(
             status_code=403, detail={"code": "forbidden", "message": "Not allowed"}
+        )
+    if entry.is_frozen:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "frozen", "message": "Entry is frozen"},
         )
 
     path = settings.data_dir / entry.audio_path

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, func, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db import Base
@@ -45,6 +45,9 @@ class Entry(Base):
     audio_size: Mapped[int] = mapped_column(Integer, nullable=False)
     audio_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
     audio_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    is_frozen: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("0")
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -27,6 +27,7 @@ class EntryOut(ORMBaseModel):
     question_id: int
     audio_mime: str
     audio_size: int
+    is_frozen: bool
     created_at: datetime
 
 

--- a/services/api/pytest.ini
+++ b/services/api/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
+testpaths = tests
+pythonpath = .
 markers =
     e2e: end-to-end tests requiring docker compose and RUN_E2E=1

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from alembic import command
 from alembic.config import Config
 from fastapi.testclient import TestClient
@@ -29,7 +30,8 @@ def _build_client(tmp_path, monkeypatch):
     app.db.SessionLocal.configure(bind=app.db.engine)
     app.main.engine = app.db.engine
 
-    alembic_cfg = Config("alembic.ini")
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
     alembic_cfg.set_main_option(
         "sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}"
     )

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
@@ -37,7 +38,8 @@ def _build_client(tmp_path, monkeypatch):
     app.db.SessionLocal.configure(bind=app.db.engine)
     app.main.engine = app.db.engine
 
-    alembic_cfg = Config("alembic.ini")
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
     alembic_cfg.set_main_option(
         "sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}"
     )

--- a/services/api/tests/test_freeze.py
+++ b/services/api/tests/test_freeze.py
@@ -1,0 +1,127 @@
+from io import BytesIO
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api/v1"
+VALID_MP3_BYTES = b"ID3\x04\x00\x00\x00\x00\x00\x00payload"
+
+
+def _build_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
+    monkeypatch.setenv("JWT_REFRESH_SECRET_KEY", "test-refresh-secret")
+    monkeypatch.setenv("APP_ENV", "development")
+
+    import app.db
+    import app.main
+    import app.settings
+
+    app.settings.settings = app.settings.Settings()
+    app.db.settings = app.settings.settings
+    app.main.settings = app.settings.settings
+
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+    app.main.engine = app.db.engine
+
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
+    alembic_cfg.set_main_option("script_location", str(api_dir / "alembic"))
+    alembic_cfg.set_main_option(
+        "sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}"
+    )
+    command.upgrade(alembic_cfg, "head")
+
+    from app.models import User
+    from app.security import hash_password
+
+    with app.db.SessionLocal() as db:
+        db.add(
+            User(
+                email="user_a@example.com",
+                password_hash=hash_password("password-a"),
+                is_active=True,
+            )
+        )
+        db.add(
+            User(
+                email="user_b@example.com",
+                password_hash=hash_password("password-b"),
+                is_active=True,
+            )
+        )
+        db.commit()
+
+    return TestClient(app.main.app)
+
+
+def _auth_headers(client: TestClient, email: str, password: str) -> dict[str, str]:
+    response = client.post(
+        f"{API_PREFIX}/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_entry(client: TestClient, headers: dict[str, str]) -> str:
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+    create = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+    assert create.status_code == 200
+    return str(create.json()["id"])
+
+
+def test_freeze_then_delete_conflict(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+    entry_id = _create_entry(client, headers)
+
+    freeze = client.post(f"{API_PREFIX}/entries/{entry_id}/freeze", headers=headers)
+    assert freeze.status_code == 200
+    assert freeze.json() == {"status": "frozen", "id": entry_id, "is_frozen": True}
+
+    delete = client.delete(f"{API_PREFIX}/entries/{entry_id}", headers=headers)
+    assert delete.status_code == 409
+    assert delete.json() == {"error": {"code": "frozen", "message": "Entry is frozen"}}
+
+
+def test_freeze_idempotent_and_forbidden_for_non_owner(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers_a = _auth_headers(client, "user_a@example.com", "password-a")
+    headers_b = _auth_headers(client, "user_b@example.com", "password-b")
+    entry_id = _create_entry(client, headers_a)
+
+    freeze_once = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/freeze", headers=headers_a
+    )
+    assert freeze_once.status_code == 200
+    assert freeze_once.json()["is_frozen"] is True
+
+    freeze_twice = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/freeze", headers=headers_a
+    )
+    assert freeze_twice.status_code == 200
+    assert freeze_twice.json()["is_frozen"] is True
+
+    freeze_other_user = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/freeze", headers=headers_b
+    )
+    assert freeze_other_user.status_code == 403
+    assert freeze_other_user.json() == {
+        "error": {"code": "forbidden", "message": "Not allowed"}
+    }

--- a/services/api/tests_e2e/conftest.py
+++ b/services/api/tests_e2e/conftest.py
@@ -139,7 +139,9 @@ def e2e_stack(e2e_base_url: str):
     """
     run_e2e = os.environ.get("RUN_E2E", "").strip().lower() in {"1", "true", "yes"}
     if not run_e2e:
-        pytest.skip("E2E disabled by default. Set RUN_E2E=1 to enable Docker E2E tests.")
+        pytest.skip(
+            "E2E disabled by default. Set RUN_E2E=1 to enable Docker E2E tests."
+        )
 
     repo = _repo_root()
 


### PR DESCRIPTION
### Motivation
- Introduce a per-entry immutable flag so users can mark entries as "frozen" to prevent deletion.
- Ensure Alembic migration discovery works reliably when tests construct the config programmatically.

### Description
- Add Alembic migration `services/api/alembic/versions/0005_entry_freeze_flag.py` to add an `is_frozen` boolean column with a `0` server default to the `entries` table.
- Add `is_frozen` mapped column to the `Entry` model in `services/api/app/models.py` with `server_default=text("0")` and a Python default of `False`.
- Add `POST /api/v1/entries/{entry_id}/freeze` endpoint in `services/api/app/main.py` that sets `entry.is_frozen = True` idempotently and returns `{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09df3a58c833096b6f3c9c1dc5248)