### PR TITLE
Améliore halo de la landing et transforme le 'o' du logo en orb animé

### DIFF
--- a/apps/web-static/index.html
+++ b/apps/web-static/index.html
@@ -10,7 +10,7 @@
     <div class="page-glow" aria-hidden="true"></div>
 
     <header class="topbar">
-      <a class="brand" href="#" aria-label="Echo">Echo</a>
+      <a class="brand" href="#" aria-label="Echo"><span class="brand-text">Ech</span><span class="orb" aria-hidden="true"></span></a>
       <a class="login-link" href="#">Se connecter</a>
     </header>
 
@@ -30,9 +30,9 @@
       </form>
 
       <div class="modes" aria-label="Modes de saisie">
-        <button type="button" class="mode-btn">🎙 Audio</button>
-        <button type="button" class="mode-btn">📝 Texte</button>
-        <button type="button" class="mode-btn">📷 Photo</button>
+        <button type="button" class="mode-btn is-active" aria-pressed="true">Audio</button>
+        <button type="button" class="mode-btn" aria-pressed="false">Texte</button>
+        <button type="button" class="mode-btn" aria-pressed="false">Photo</button>
       </div>
     </main>
 

--- a/apps/web-static/styles.css
+++ b/apps/web-static/styles.css
@@ -6,8 +6,9 @@
   --muted: #9eacb9;
   --border: rgba(201, 218, 232, 0.16);
   --border-focus: rgba(201, 218, 232, 0.28);
-  --halo-soft: rgba(96, 144, 178, 0.16);
-  --halo-outer: rgba(58, 94, 122, 0.02);
+  --halo-soft: rgba(96, 144, 178, 0.14);
+  --halo-orb-core: rgba(188, 224, 247, 0.9);
+  --halo-orb-soft: rgba(130, 184, 216, 0.62);
 }
 
 * {
@@ -30,20 +31,24 @@ body {
 
 .page-glow {
   position: fixed;
-  inset: 0;
+  inset: -14% -10%;
   pointer-events: none;
-  background:
-    radial-gradient(55% 35% at 50% 50%, var(--halo-soft), transparent 70%),
-    radial-gradient(40% 25% at 50% 45%, var(--halo-outer), transparent 90%);
-  opacity: 0.32;
-  filter: blur(34px);
-  transform: scale(1);
-  transition: opacity 0.8s ease;
-  animation: breathe 52s ease-in-out infinite;
+  z-index: 0;
+  background: radial-gradient(60% 54% at 50% 46%, var(--halo-soft), transparent 76%);
+  opacity: 0.34;
+  filter: blur(54px);
+  transform: translate3d(0, 0, 0) scale(1);
+  animation: glowDrift 55s ease-in-out infinite;
 }
 
 body.is-focused .page-glow {
-  opacity: 0.37; /* +5% max when field focused */
+  opacity: 0.38;
+}
+
+.topbar,
+.hero {
+  position: relative;
+  z-index: 1;
 }
 
 .topbar {
@@ -61,8 +66,27 @@ body.is-focused .page-glow {
 }
 
 .brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.05em;
   font-size: 1rem;
   font-weight: 600;
+}
+
+.brand-text {
+  display: inline-block;
+}
+
+.orb {
+  width: 0.64em;
+  height: 0.64em;
+  margin-left: 0.02em;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 36%, var(--halo-orb-core), var(--halo-orb-soft) 58%, transparent 100%);
+  box-shadow: 0 0 0.52em rgba(166, 212, 241, 0.4);
+  filter: blur(0.2px);
+  transform: translateY(-0.02em);
+  animation: orbPulse 8s ease-in-out infinite;
 }
 
 .login-link {
@@ -138,16 +162,19 @@ input::placeholder {
 }
 
 .modes {
-  display: flex;
-  gap: 0.55rem;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(201, 218, 232, 0.16);
+  background: rgba(24, 35, 44, 0.56);
 }
 
 .mode-btn {
-  border: 1px solid rgba(201, 218, 232, 0.16);
+  border: 0;
   border-radius: 999px;
-  background: rgba(24, 35, 44, 0.72);
+  background: transparent;
   color: #d5dee5;
   font-size: 0.9rem;
   padding: 0.45rem 0.85rem;
@@ -155,7 +182,12 @@ input::placeholder {
 }
 
 .mode-btn:hover {
-  background: rgba(32, 46, 57, 0.8);
+  background: rgba(53, 73, 88, 0.42);
+}
+
+.mode-btn.is-active {
+  background: rgba(201, 218, 232, 0.16);
+  color: #f0f5f9;
 }
 
 .mode-btn:focus-visible,
@@ -178,15 +210,34 @@ input::placeholder {
   border: 0;
 }
 
-@keyframes breathe {
+@keyframes glowDrift {
   0%,
   100% {
-    transform: scale(1);
-    opacity: 0.31;
+    transform: translate3d(-0.4%, -0.6%, 0) scale(1);
+    opacity: 0.32;
   }
   50% {
-    transform: scale(1.02);
-    opacity: 0.34;
+    transform: translate3d(0.4%, 0.5%, 0) scale(1.018);
+    opacity: 0.36;
+  }
+}
+
+@keyframes orbPulse {
+  0%,
+  100% {
+    opacity: 0.86;
+    transform: translateY(-0.02em) scale(0.96);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-0.03em) scale(1.02);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-glow,
+  .orb {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Moderniser la landing en remplaçant le « o » du logo par un petit halo flou animé pour une direction visuelle minimale sans emoji ni icônes.
- Simplifier la zone de glow en un unique halo diffus très lent avec micro-drift pour un rendu subtil et non distrayant.
- Préserver l'option de contrôle segmenté Audio/Texte/Photo et s'assurer que le contenu reste net au-dessus de l'effet visuel via `z-index`.

### Description
- Mise à jour de `apps/web-static/index.html` pour remplacer `Echo` par `<span class="brand-text">Ech</span><span class="orb" aria-hidden="true"></span>` et retirer les emoji des boutons de mode en conservant l'état actif et `aria-pressed`.
- Réécriture de `apps/web-static/styles.css` pour transformer `.page-glow` en un seul radial diffus animé très lentement (`55s` via `@keyframes glowDrift`) avec micro-drift, élargir le flou, et positionner `.topbar`/`.hero` au-dessus (`z-index`).
- Ajout des styles de l'`orb` (taille, dégradé radial, halo, animation `orbPulse`) et ajustement visuel du contrôle segmenté (`.modes`, `.mode-btn`) pour un rendu minimaliste.
- Ajout de `@media (prefers-reduced-motion: reduce)` pour désactiver les animations décoratives (`.page-glow`, `.orb`).

### Testing
- Exécution de `git status --short` et inspection du diff via `git show` ont confirmé les modifications et le commit (`Refine landing halo and logo orb animation`) a été créé avec succès.
- Démarrage d'un serveur local avec `python -m http.server 4173 --directory apps/web-static` a fonctionné pour tester la page localement.
- Tentative de capture visuelle via Playwright a échoué pour des raisons environnementales (Chromium a planté avec SIGSEGV), donc aucun screenshot automatisé n'a été produit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a141af18b88330a25c2efe2d3c27c4)