### PR TITLE
Refactor web-static into single-screen memories SPA

### DIFF
--- a/apps/web-static/app.js
+++ b/apps/web-static/app.js
@@ -1,21 +1,205 @@
-// Intensifie légèrement le halo quand le champ principal reçoit le focus.
-const ta = document.getElementById("echo-input");
+const memories = [
+  {
+    id: 1,
+    date: "2026-01-10",
+    text: "J'ai retrouvé une photo de famille ce matin.",
+    audio: true,
+    image: true,
+  },
+  {
+    id: 2,
+    date: "2026-01-05",
+    text: "Promenade calme au parc.",
+    audio: false,
+    image: false,
+  },
+  {
+    id: 3,
+    date: "2025-12-28",
+    text: "",
+    audio: true,
+    image: false,
+  },
+];
 
-function autosize(el) {
-  el.style.height = "auto";
+const imageSamples = [
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop stop-color='%233a5a74'/%3E%3Cstop offset='1' stop-color='%2392b4c8'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='640' height='360' fill='url(%23g)'/%3E%3Ccircle cx='190' cy='152' r='68' fill='%23ffffff22'/%3E%3C/svg%3E",
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='1' x2='1' y2='0'%3E%3Cstop stop-color='%23223a4a'/%3E%3Cstop offset='1' stop-color='%237ca0b5'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='640' height='360' fill='url(%23g)'/%3E%3Crect x='120' y='86' width='380' height='190' rx='16' fill='%23ffffff1e'/%3E%3C/svg%3E",
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='0'%3E%3Cstop stop-color='%2331424d'/%3E%3Cstop offset='1' stop-color='%235f7f93'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='640' height='360' fill='url(%23g)'/%3E%3Cpath d='M120 260l108-124 95 82 70-58 124 100z' fill='%23ffffff20'/%3E%3C/svg%3E",
+];
 
-  const styles = window.getComputedStyle(el);
-  const maxH = parseFloat(styles.maxHeight) || Infinity;
+let currentMemoryId = null;
+let audioState = "idle";
+let imageUrl = "";
 
-  const next = Math.min(el.scrollHeight, maxH);
-  el.style.height = next + "px";
+const timelineList = document.getElementById("timeline-list");
+const timelinePanel = document.querySelector(".timeline-panel");
+const timelineToggle = document.getElementById("timeline-toggle");
+const textInput = document.getElementById("memory-text");
+const audioButton = document.getElementById("audio-action");
+const audioStatus = document.getElementById("audio-status");
+const imageAddBtn = document.getElementById("image-add");
+const imageRemoveBtn = document.getElementById("image-remove");
+const imagePreview = document.getElementById("image-preview");
+const saveButton = document.getElementById("save-memory");
 
-  // si on dépasse max, on laisse scroll interne
-  el.style.overflowY = el.scrollHeight > maxH ? "auto" : "hidden";
+function formatDate(value) {
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(value));
 }
 
-if (ta) {
-  autosize(ta);
-  ta.addEventListener("input", () => autosize(ta));
-  window.addEventListener("resize", () => autosize(ta));
+function getExcerpt(text) {
+  const cleaned = (text || "").trim();
+  if (!cleaned) return "Sans texte";
+  return cleaned.length > 72 ? `${cleaned.slice(0, 72)}…` : cleaned;
 }
+
+function autosizeTextarea() {
+  textInput.style.height = "auto";
+  const maxHeight = parseFloat(window.getComputedStyle(textInput).maxHeight) || Infinity;
+  const nextHeight = Math.min(textInput.scrollHeight, maxHeight);
+  textInput.style.height = `${nextHeight}px`;
+  textInput.style.overflowY = textInput.scrollHeight > maxHeight ? "auto" : "hidden";
+}
+
+function syncSaveState() {
+  const hasText = textInput.value.trim().length > 0;
+  const hasAudio = audioState === "recorded";
+  const hasImage = Boolean(imageUrl);
+  saveButton.disabled = !(hasText || hasAudio || hasImage);
+}
+
+function setAudioState(nextState) {
+  audioState = nextState;
+
+  if (audioState === "idle") {
+    audioButton.textContent = "Enregistrer ma voix";
+    audioStatus.textContent = "Aucun audio";
+  } else if (audioState === "recording") {
+    audioButton.textContent = "Stop (simulation)";
+    audioStatus.textContent = "Enregistrement…";
+  } else {
+    audioButton.textContent = "Réenregistrer";
+    audioStatus.textContent = "Audio ajouté";
+  }
+
+  syncSaveState();
+}
+
+function renderImagePreview() {
+  if (!imageUrl) {
+    imagePreview.innerHTML = "<p>Pas d'image ajoutée.</p>";
+    imageRemoveBtn.disabled = true;
+  } else {
+    imagePreview.innerHTML = `<img src="${imageUrl}" alt="Aperçu de la photo du souvenir" />`;
+    imageRemoveBtn.disabled = false;
+  }
+
+  syncSaveState();
+}
+
+function renderTimeline() {
+  const sorted = [...memories].sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  timelineList.innerHTML = sorted
+    .map((memory) => {
+      const indicators = [memory.audio ? "🎙" : "", memory.image ? "🖼" : ""]
+        .filter(Boolean)
+        .join(" ");
+
+      return `
+        <button class="timeline-item ${memory.id === currentMemoryId ? "is-active" : ""}" data-id="${memory.id}" type="button">
+          <p class="meta">${formatDate(memory.date)} ${indicators}</p>
+          <p class="excerpt">${getExcerpt(memory.text)}</p>
+        </button>
+      `;
+    })
+    .join("");
+}
+
+function loadMemory(memoryId) {
+  const memory = memories.find((item) => item.id === memoryId);
+  if (!memory) return;
+
+  currentMemoryId = memory.id;
+  textInput.value = memory.text || "";
+  setAudioState(memory.audio ? "recorded" : "idle");
+  imageUrl = memory.image ? imageSamples[memory.id % imageSamples.length] : "";
+  renderImagePreview();
+  autosizeTextarea();
+  renderTimeline();
+}
+
+function saveMemory() {
+  const payload = {
+    text: textInput.value.trim(),
+    audio: audioState === "recorded",
+    image: Boolean(imageUrl),
+  };
+
+  if (currentMemoryId) {
+    const index = memories.findIndex((item) => item.id === currentMemoryId);
+    if (index >= 0) {
+      memories[index] = {
+        ...memories[index],
+        ...payload,
+        date: new Date().toISOString().slice(0, 10),
+      };
+    }
+  } else {
+    const nextId = Math.max(0, ...memories.map((item) => item.id)) + 1;
+    currentMemoryId = nextId;
+    memories.push({
+      id: nextId,
+      ...payload,
+      date: new Date().toISOString().slice(0, 10),
+    });
+  }
+
+  renderTimeline();
+}
+
+textInput.addEventListener("input", () => {
+  autosizeTextarea();
+  syncSaveState();
+});
+window.addEventListener("resize", autosizeTextarea);
+
+audioButton.addEventListener("click", () => {
+  if (audioState === "idle") {
+    setAudioState("recording");
+  } else if (audioState === "recording") {
+    setAudioState("recorded");
+  } else {
+    setAudioState("idle");
+  }
+});
+
+imageAddBtn.addEventListener("click", () => {
+  imageUrl = imageSamples[Math.floor(Math.random() * imageSamples.length)];
+  renderImagePreview();
+});
+
+imageRemoveBtn.addEventListener("click", () => {
+  imageUrl = "";
+  renderImagePreview();
+});
+
+saveButton.addEventListener("click", saveMemory);
+
+timelineList.addEventListener("click", (event) => {
+  const item = event.target.closest(".timeline-item");
+  if (!item) return;
+  loadMemory(Number(item.dataset.id));
+});
+
+timelineToggle.addEventListener("click", () => {
+  const open = timelinePanel.classList.toggle("is-open");
+  timelineToggle.setAttribute("aria-expanded", String(open));
+});
+
+renderTimeline();
+loadMemory(memories[0].id);

--- a/apps/web-static/index.html
+++ b/apps/web-static/index.html
@@ -3,58 +3,70 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>echo — Accueil</title>
+    <title>echo — Souvenirs</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
-
   <body>
-    <a class="sr-only" href="#main">Aller au contenu principal</a>
-
+    <a class="sr-only" href="#workspace">Aller à l'éditeur</a>
     <div class="page-glow" aria-hidden="true"></div>
 
     <header class="topbar" role="banner">
       <div class="topbar-inner">
-        <a class="brand" href="/" aria-label="echo (accueil)">
-          <svg class="brand-mark" viewBox="0 0 90 24" role="img" aria-label="echo">
-            <text
-              x="0"
-              y="18"
-              font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-              font-size="18"
-              font-weight="600"
-              letter-spacing="1"
-              fill="currentColor"
-            >
-              echo
-            </text>
-          </svg>
-        </a>
-
-        <nav aria-label="Compte">
-          <a class="login-link" href="/login">Log in</a>
-        </nav>
+        <p class="brand" aria-label="echo">echo</p>
+        <button class="ghost-btn" type="button" aria-label="Compte">Compte</button>
       </div>
     </header>
 
-    <main id="main" class="hero" role="main">
-      <h1>Que veux-tu transmettre aujourd’hui ?</h1>
+    <main class="app-shell" role="main">
+      <section class="timeline-panel" aria-label="Timeline des souvenirs">
+        <button
+          id="timeline-toggle"
+          class="timeline-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="timeline-list"
+        >
+          Voir les souvenirs
+        </button>
+        <div id="timeline-list" class="timeline-list"></div>
+      </section>
 
-      <form class="input-shell" action="#" method="get" aria-label="Créer une entrée">
-        <label for="echo-input" class="sr-only">Entrée principale</label>
-        <textarea
-		  id="echo-input"
-		  name="q"
-		  rows="1"
-		  placeholder="Un souvenir, une pensée, une note…"
-		></textarea>
-        <button type="submit" class="primary-action">Commencer</button>
-      </form>
+      <section id="workspace" class="workspace" aria-label="Éditeur de souvenir">
+        <h1>Ton souvenir</h1>
 
-      <div class="modes" role="group" aria-label="Mode de saisie">
-        <button type="button" class="mode-btn is-active" aria-pressed="true">Audio</button>
-        <button type="button" class="mode-btn" aria-pressed="false">Texte</button>
-        <button type="button" class="mode-btn" aria-pressed="false">Photo</button>
-      </div>
+        <article class="editor-block" aria-labelledby="text-title">
+          <h2 id="text-title">Texte</h2>
+          <label class="sr-only" for="memory-text">Texte du souvenir</label>
+          <textarea
+            id="memory-text"
+            rows="1"
+            placeholder="Écris une pensée, un souvenir, une note…"
+          ></textarea>
+        </article>
+
+        <article class="editor-block" aria-labelledby="audio-title">
+          <h2 id="audio-title">Voix</h2>
+          <div class="row-wrap">
+            <button id="audio-action" class="soft-btn" type="button">Enregistrer ma voix</button>
+            <p id="audio-status" class="status">Aucun audio</p>
+          </div>
+        </article>
+
+        <article class="editor-block" aria-labelledby="image-title">
+          <h2 id="image-title">Image</h2>
+          <div class="row-wrap">
+            <button id="image-add" class="soft-btn" type="button">Ajouter une photo</button>
+            <button id="image-remove" class="ghost-btn" type="button">Supprimer</button>
+          </div>
+          <div id="image-preview" class="image-preview" aria-live="polite">
+            <p>Pas d'image ajoutée.</p>
+          </div>
+        </article>
+
+        <button id="save-memory" class="primary-action" type="button" disabled>
+          Enregistrer le souvenir
+        </button>
+      </section>
     </main>
 
     <script src="./app.js"></script>

--- a/apps/web-static/styles.css
+++ b/apps/web-static/styles.css
@@ -1,34 +1,20 @@
 :root {
   --bg: #0e1419;
-
   --text: #ffffff;
   --muted: #9eacb9;
-
   --halo-soft: rgba(96, 144, 178, 0.14);
-
-  /* Header */
   --header-h: 56px;
   --header-bg: rgba(14, 20, 25, 0.58);
-
-  /* Layout */
   --pad-x: 16px;
   --pad-x-md: 24px;
-
-  /* Focus (very subtle) */
   --focus: rgba(255, 255, 255, 0.18);
-
-  /* Surfaces */
   --surface: rgba(255, 255, 255, 0.08);
   --surface-focus: rgba(255, 255, 255, 0.11);
-
-  /* CTA / “Commencer” + scrollbar thumb */
-  --btn-bg: rgba(189, 213, 230, 0.10);
+  --btn-bg: rgba(189, 213, 230, 0.1);
   --btn-bg-hover: rgba(189, 213, 230, 0.16);
-  --btn-bg-active: rgba(189, 213, 230, 0.20);
-  
-  /* Fonts */
-  --font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-        Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  --btn-bg-active: rgba(189, 213, 230, 0.2);
+  --font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
 }
 
 * {
@@ -42,14 +28,11 @@ body {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--font);
   background: var(--bg);
   color: var(--text);
-  display: flex;
-  flex-direction: column;
 }
 
-/* Ambient glow */
 .page-glow {
   position: fixed;
   inset: -18% -12%;
@@ -58,260 +41,214 @@ body {
   background: radial-gradient(60% 54% at 50% 46%, var(--halo-soft), transparent 76%);
   opacity: 0.22;
   filter: blur(70px);
-  transform: translate3d(0, 0, 0) scale(1);
-  animation: glowDrift 55s ease-in-out infinite;
 }
 
-/* Header */
 .topbar {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  inset: 0 0 auto;
   height: var(--header-h);
-  z-index: 51;
-
+  z-index: 2;
   background: var(--header-bg);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
-  border-bottom: 0;
 }
 
 .topbar-inner {
   height: 100%;
-  width: 100%;
-
   display: flex;
   align-items: center;
   justify-content: space-between;
-
   padding: 0 var(--pad-x);
-  max-width: none;
-  margin: 0;
-}
-
-@media (min-width: 768px) {
-  .topbar-inner {
-    padding: 0 var(--pad-x-md);
-  }
-}
-
-/* Brand + login */
-.brand,
-.login-link {
-  text-decoration: none;
-  color: var(--text);
-  letter-spacing: 0.01em;
 }
 
 .brand {
-  display: inline-flex;
-  align-items: center;
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
-.brand-mark {
-  width: 110px;
-  height: auto;
-  display: block;
+.ghost-btn,
+.soft-btn,
+.primary-action,
+.timeline-toggle {
+  border: 0;
+  color: var(--text);
+  font-family: inherit;
+  cursor: pointer;
 }
 
-@media (min-width: 768px) {
-  .brand-mark {
-    width: 122px;
-  }
-}
-
-.login-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  height: 40px;
-  padding: 0 20px;
-
-  font-size: 0.85rem;
-  font-weight: 500;
-  line-height: 1;
-
+.ghost-btn,
+.soft-btn,
+.timeline-toggle {
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-
-  transition: background-color 0.15s ease, transform 0.08s ease;
+  font-size: 0.82rem;
+  padding: 0.55rem 0.92rem;
+  background: var(--surface);
 }
 
-.login-link:hover {
-  background: rgba(255, 255, 255, 0.12);
+.soft-btn {
+  background: var(--btn-bg);
 }
 
-.login-link:active {
-  transform: translateY(1px);
-  background: rgba(255, 255, 255, 0.14);
-}
-
-.login-link:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 2px;
-}
-
-/* Hero */
-.hero {
+.app-shell {
   position: relative;
   z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: 1rem;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: calc(var(--header-h) + 1rem) var(--pad-x) 1.5rem;
+}
 
-  flex: 1;
+.timeline-panel,
+.workspace,
+.editor-block,
+.timeline-item,
+.image-preview {
+  background: var(--surface);
+  border-radius: 1rem;
+}
+
+.timeline-panel {
+  padding: 0.8rem;
+  align-self: start;
+  position: sticky;
+  top: calc(var(--header-h) + 1rem);
+}
+
+.timeline-toggle {
+  display: none;
+  width: 100%;
+  margin-bottom: 0.65rem;
+}
+
+.timeline-list {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
+  gap: 0.5rem;
+  max-height: calc(100vh - 110px);
+  overflow: auto;
+}
 
-  width: min(92vw, 48rem);
-  margin: 0 auto;
-  text-align: center;
+.timeline-item {
+  width: 100%;
+  border: 0;
+  text-align: left;
+  padding: 0.75rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+}
 
-  /* You asked for “lower” */
-  padding: calc(var(--header-h) + 20rem) 0 6rem;
-  gap: 1.35rem;
+.timeline-item.is-active {
+  background: var(--surface-focus);
+}
+
+.meta,
+.excerpt,
+.status {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.83rem;
+}
+
+.excerpt {
+  margin-top: 0.4rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.workspace {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 h1 {
   margin: 0;
-  max-width: 40ch;
-  font-size: clamp(1.2rem, 2vw, 1.8rem);
-  line-height: 1.25;
+  font-size: 1.2rem;
   font-weight: 550;
-  letter-spacing: -0.01em;
 }
 
-/* Input shell (no borders, no outlines, just a brighter surface) */
-.input-shell {
-  width: min(100%, 40rem);
+.editor-block {
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+h2 {
+  margin: 0 0 0.6rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+#memory-text {
+  width: 100%;
+  min-height: 56px;
+  max-height: 184px;
+  resize: none;
+  overflow-y: auto;
+  padding: 0.7rem;
+  color: var(--text);
+  border: 0;
+  border-radius: 0.8rem;
+  outline: 0;
+  background: rgba(255, 255, 255, 0.05);
+  font: inherit;
+  line-height: 1.35;
+}
+
+.row-wrap {
   display: flex;
   align-items: center;
-
-  gap: 0.75rem;
-  padding: 0.6rem;
-
-  border-radius: 1.1rem;
-  background: var(--surface);
-  border: 0;
-  box-shadow: none;
-
-  transition: background-color 0.2s ease;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
-.input-shell:focus-within {
-  background: var(--surface-focus);
+.image-preview {
+  min-height: 120px;
+  margin-top: 0.7rem;
+  background: rgba(255, 255, 255, 0.03);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
 }
 
-/* Textarea (autosize + internal scroll after max-height) */
-textarea {
-  font-family: inherit;            /* IMPORTANT */
-  font-weight: 450;                /* un peu plus clean que 400 */
-  letter-spacing: -0.005em;        /* très léger, rend plus “OpenAI” */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
-  /* le reste de tes styles */
-  flex: 1;
-  min-width: 0;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: var(--text);
-  padding: 1.05rem 1rem;
-  font-size: 0.95rem;
-  line-height: 1.35;
-
-  resize: none;
-  white-space: pre-wrap;
-  word-break: break-word;
-
-  max-height: 11.5rem;
-  overflow-y: auto;
-  scrollbar-gutter: stable;
+.image-preview img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
 }
 
-textarea::placeholder {
-  color: rgba(255, 255, 255, 0.45);
-}
-
-/* Primary action */
 .primary-action {
-  border: 0;
-  box-shadow: none;
-
-  background: var(--btn-bg);
-  color: var(--text);
-
+  margin-top: 0.2rem;
   border-radius: 0.85rem;
-  padding: 0.72rem 1rem;
-  font-size: 0.9rem;
-
-  cursor: pointer;
-  transition: background-color 0.15s ease, transform 0.08s ease;
+  padding: 0.82rem 1rem;
+  font-size: 0.95rem;
+  background: var(--btn-bg);
+  transition: background-color 0.15s ease;
 }
 
-.primary-action:hover {
+.primary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.primary-action:not(:disabled):hover,
+.soft-btn:hover,
+.ghost-btn:hover,
+.timeline-toggle:hover {
   background: var(--btn-bg-hover);
 }
 
-.primary-action:active {
-  transform: translateY(1px);
-  background: var(--btn-bg-active);
-}
-
-.primary-action:focus-visible {
+button:focus-visible,
+textarea:focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
 }
 
-/* Segmented control */
-.modes {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.2rem;
-
-  padding: 0.22rem;
-  border-radius: 999px;
-
-  border: 0;
-  background: rgba(24, 35, 44, 0.40);
-  box-shadow: none;
-}
-
-.mode-btn {
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-
-  color: rgba(213, 222, 229, 0.92);
-  font-size: 0.88rem;
-  padding: 0.45rem 0.85rem;
-
-  cursor: pointer;
-  transition: background-color 0.15s ease, transform 0.08s ease;
-}
-
-.mode-btn:hover {
-  background: rgba(53, 73, 88, 0.28);
-}
-
-.mode-btn.is-active {
-  background: rgba(201, 218, 232, 0.14);
-  color: #f0f5f9;
-}
-
-.mode-btn:active {
-  transform: translateY(1px);
-}
-
-.mode-btn:focus-visible,
-.brand:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 2px;
-}
-
-/* Screen-reader only */
 .sr-only {
   position: absolute;
   width: 1px;
@@ -324,72 +261,34 @@ textarea::placeholder {
   border: 0;
 }
 
-/* Scrollbar styling (no track background, thumb like “Commencer”) */
-/* Firefox */
-textarea {
-  scrollbar-width: thin;
-  scrollbar-color: var(--btn-bg) transparent;
-}
-
-/* WebKit */
-textarea::-webkit-scrollbar {
-  width: 10px;
-}
-
-textarea::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-textarea::-webkit-scrollbar-thumb {
-  background: var(--btn-bg);
-  border-radius: 999px;
-  border: 3px solid transparent;
-  background-clip: padding-box;
-}
-
-textarea::-webkit-scrollbar-thumb:hover {
-  background: var(--btn-bg-hover);
-  border: 3px solid transparent;
-  background-clip: padding-box;
-}
-
-/* Try to avoid visible arrow buttons where they exist */
-textarea::-webkit-scrollbar-button {
-  background: transparent;
-  height: 0;
-}
-
-/* Animations */
-@keyframes glowDrift {
-  0%,
-  100% {
-    transform: translate3d(-0.4%, -0.6%, 0) scale(1);
-    opacity: 0.20;
-  }
-  50% {
-    transform: translate3d(0.4%, 0.5%, 0) scale(1.02);
-    opacity: 0.26;
+@media (min-width: 768px) {
+  .topbar-inner,
+  .app-shell {
+    padding-left: var(--pad-x-md);
+    padding-right: var(--pad-x-md);
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .page-glow {
-    animation: none;
-  }
-}
-
-/* Mobile */
-@media (max-width: 520px) {
-  .hero {
-    padding: calc(var(--header-h) + 5.75rem) 0 4.2rem;
+@media (max-width: 860px) {
+  .app-shell {
+    grid-template-columns: 1fr;
   }
 
-  .input-shell {
-    flex-direction: column;
-    align-items: stretch;
+  .timeline-panel {
+    position: static;
   }
 
-  .primary-action {
-    width: 100%;
+  .timeline-toggle {
+    display: inline-flex;
+    justify-content: center;
+  }
+
+  .timeline-list {
+    max-height: 260px;
+    display: none;
+  }
+
+  .timeline-panel.is-open .timeline-list {
+    display: flex;
   }
 }


### PR DESCRIPTION
### Motivation

- Transformer la page statique existante en une application mono-écran (SPA) claire et accessible tout en conservant le thème sombre minimaliste et les variables CSS existantes. 
- Offrir une UI simple pour créer/éditer un « souvenir » (texte, audio, image) sans navigation ni redirections.
- Fournir une base JS/CSS/HTML vanilla facile à lire et à maintenir.

### Description

- Réorganisation complète de la vue en layout deux colonnes : une `timeline` à gauche et un `workspace` central contenant trois blocs (Texte / Voix / Image) et le bouton principal `Enregistrer le souvenir`. 
- JavaScript mock : ajout d'un dataset de souvenirs, rendu chronologique de la timeline, clic sur un item charge directement l’éditeur, autosize du `textarea`, simulation des états audio (`idle/recording/recorded`) et simulation d’ajout/suppression d’image avec preview, et activation du bouton d’enregistrement lorsque au moins un média est présent (texte ou audio ou image). 
- CSS refactor : conservation des variables CSS, maintien du style sombre minimaliste, composants sobres (pas de bordures inutiles), textarea avec max-height + scroll interne, et comportement responsive où la timeline devient un panneau repliable sur mobile. 
- Skills : aucune des compétences listées dans `AGENTS.md` n’a été utilisée pour ce changement.

### Testing

- `node --check apps/web-static/app.js` exécuté et a réussi (aucune erreur de syntaxe JS). 
- Démarrage d’un serveur local `python -m http.server 8000` puis capture visuelle via Playwright pour valider le rendu (`artifacts/web-static-spa.png`) réussie. 
- Vérification manuelle automatisée minimale : interactions simulées via le script de test visuel (screenshot) pour confirmer rendu et état initial de la timeline et de l’éditeur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1784139048330a50fff46858f3626)