### PR TITLE
feat(api): add optional text_content to entries with DB migration and validation

### DIFF
--- a/services/api/alembic/versions/0006_entry_text_content.py
+++ b/services/api/alembic/versions/0006_entry_text_content.py
@@ -1,0 +1,25 @@
+"""add text content for entries
+
+Revision ID: 0006_entry_text_content
+Revises: 0005_entry_freeze_flag
+Create Date: 2026-02-27
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0006_entry_text_content"
+down_revision: Union[str, None] = "0005_entry_freeze_flag"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("entries", sa.Column("text_content", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("entries", "text_content")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -195,6 +195,22 @@ def _ensure_not_frozen(entry: Entry) -> None:
         raise HTTPException(status_code=409, detail=FROZEN_ERROR)
 
 
+def _validate_text_content(text_content: str | None) -> None:
+    if text_content is None:
+        return
+    if len(text_content) > settings.max_text_chars:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "text_content_too_long",
+                "message": (
+                    "text_content length exceeds "
+                    f"MAX_TEXT_CHARS ({settings.max_text_chars})"
+                ),
+            },
+        )
+
+
 @api_v1_router.get("/questions/today", response_model=QuestionOut)
 def get_question_today(
     _: User = Depends(get_current_user), db: Session = Depends(get_db)
@@ -216,6 +232,7 @@ def get_question_today(
 @api_v1_router.post("/entries", response_model=EntryOut)
 async def create_entry(
     question_id: int = Form(...),
+    text_content: str | None = Form(default=None),
     audio_file: UploadFile = File(...),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -234,6 +251,8 @@ async def create_entry(
                 "message": "Unsupported audio MIME type",
             },
         )
+
+    _validate_text_content(text_content)
 
     entry_id = str(uuid.uuid4())
     ext = ALLOWED_MIME_TYPES[content_type]
@@ -256,6 +275,7 @@ async def create_entry(
         audio_size=int(upload_info["size"]),
         audio_sha256=str(upload_info["sha256"]),
         audio_duration_ms=upload_info["duration_ms"],
+        text_content=text_content,
     )
     db.add(entry)
     db.commit()
@@ -351,11 +371,25 @@ def update_entry(
     _ensure_owner(entry, current_user)
     _ensure_not_frozen(entry)
 
-    question = db.get(Question, payload.question_id)
-    if question is None:
-        raise HTTPException(status_code=404, detail="Question not found")
+    if payload.question_id is None and payload.text_content is None:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "empty_update",
+                "message": "At least one updatable field must be provided",
+            },
+        )
 
-    entry.question_id = payload.question_id
+    if payload.question_id is not None:
+        question = db.get(Question, payload.question_id)
+        if question is None:
+            raise HTTPException(status_code=404, detail="Question not found")
+        entry.question_id = payload.question_id
+
+    if payload.text_content is not None:
+        _validate_text_content(payload.text_content)
+        entry.text_content = payload.text_content
+
     db.commit()
     db.refresh(entry)
     return entry

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -1,7 +1,16 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, func, text
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db import Base
@@ -45,6 +54,7 @@ class Entry(Base):
     audio_size: Mapped[int] = mapped_column(Integer, nullable=False)
     audio_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
     audio_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    text_content: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_frozen: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("0")
     )

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -27,12 +27,14 @@ class EntryOut(ORMBaseModel):
     question_id: int
     audio_mime: str
     audio_size: int
+    text_content: Optional[str] = None
     is_frozen: bool
     created_at: datetime
 
 
 class EntryUpdateIn(BaseModel):
-    question_id: int
+    question_id: Optional[int] = None
+    text_content: Optional[str] = None
 
 
 class EntriesListResponse(ORMBaseModel):

--- a/services/api/app/settings.py
+++ b/services/api/app/settings.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
     app_env: str = "development"
     data_dir: Path = Path("/app/data")
     max_upload_size_mb: int = 25
+    # Maximum allowed size for optional entry text content.
+    max_text_chars: int = 10_000
 
     jwt_secret_key: str = ""
     jwt_refresh_secret_key: str = ""

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -207,3 +207,50 @@ def test_legacy_root_endpoints_removed(tmp_path, monkeypatch):
     assert client.get("/questions/today").status_code == 404
     assert client.get("/entries").status_code == 404
     assert client.get("/entries/not-found").status_code == 404
+
+
+def test_create_entry_with_text_content_and_readback(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    created = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text_content": "hello"},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+
+    assert created.status_code == 200
+    assert created.json()["text_content"] == "hello"
+
+    entry_id = created.json()["id"]
+    fetched = client.get(f"{API_PREFIX}/entries/{entry_id}", headers=headers)
+    assert fetched.status_code == 200
+    assert fetched.json()["text_content"] == "hello"
+
+
+def test_text_content_length_validation(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAX_TEXT_CHARS", "5")
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text_content": "bonjour"},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "error": {
+            "code": "text_content_too_long",
+            "message": "text_content length exceeds MAX_TEXT_CHARS (5)",
+        }
+    }

--- a/services/api/tests/test_freeze.py
+++ b/services/api/tests/test_freeze.py
@@ -144,7 +144,7 @@ def test_mutations_blocked_when_frozen(tmp_path, monkeypatch):
 
     update = client.patch(
         f"{API_PREFIX}/entries/{entry_id}",
-        json={"question_id": question_id},
+        json={"question_id": question_id, "text_content": "frozen update"},
         headers=headers,
     )
     assert update.status_code == 409


### PR DESCRIPTION
### Motivation
- Permettre de stocker un texte persistant associé à une `entry` (issue P0-2) tout en restant compatible avec les clients existants (champ nullable et optionnel). 
- Respecter la règle de freeze existante pour empêcher toute mutation du champ `text_content` quand `entry.is_frozen` est vrai.

### Description
- Ajout d’une migration Alembic `services/api/alembic/versions/0006_entry_text_content.py` qui crée la colonne nullable `entries.text_content` de type `TEXT` et la supprime au `downgrade`.
- Mise à jour du modèle SQLAlchemy `Entry` pour exposer `text_content: Optional[str]` mappé en `Text(nullable=True)`.
- Mise à jour des schémas Pydantic pour inclure `text_content` en sortie (`EntryOut`) et l’accepter en entrée/patch (`EntryUpdateIn`), et rendre `question_id` optionnel lors du `PATCH` pour permettre mises à jour partielles.
- API: `POST /api/v1/entries` accepte un champ form `text_content` optionnel et le stocke; `PATCH /api/v1/entries/{id}` accepte `text_content` pour mise à jour partielle; la validation de longueur réutilise un helper et renvoie HTTP 422 avec le code `text_content_too_long` si dépassé; la règle de freeze (`ENTRY_FROZEN_IMMUTABLE`) est appliquée pour bloquer les mutations quand pertinent.
- Ajout d’un paramètre de configuration `MAX_TEXT_CHARS` (exposé via la setting `max_text_chars`) avec valeur par défaut `10_000` pour limiter la taille du texte.
- Tests: ajout d’un test de création + lecture vérifiant `text_content`, ajout d’un test de validation de longueur, et adaptation d’un test de freeze pour inclure une tentative de mise à jour de `text_content`.

### Testing
- Tests exécutés: `pytest -q tests/test_entries.py tests/test_freeze.py` et les tests ciblés ont réussi.
- Résultat: les tests automatisés sont passés (suite exécutée: 16 passed, 3 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e02dd0708330ae5cd86ef91ac44e)