### PR TITLE
refactor(api): migrate startup initialization to FastAPI lifespan handler

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,4 +1,5 @@
 from datetime import date
+from contextlib import asynccontextmanager
 import logging
 from pathlib import Path
 from typing import Literal
@@ -31,9 +32,29 @@ from app.security import get_current_user, hash_password
 from app.settings import settings
 from app.storage import ALLOWED_MIME_TYPES, stream_upload_to_disk
 
-app = FastAPI(title=settings.app_name, version=settings.app_version)
 logger = logging.getLogger(__name__)
 api_v1_router = APIRouter(prefix="/api/v1")
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    configure_json_logging()
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    settings.audio_dir.mkdir(parents=True, exist_ok=True)
+    if not inspect(engine).has_table("entries"):
+        logger.warning("Database not initialized. Run: alembic upgrade head")
+        yield
+        return
+
+    with Session(engine) as db:
+        _seed_admin_user(db)
+
+    yield
+
+
+app = FastAPI(title=settings.app_name, version=settings.app_version, lifespan=lifespan)
+
+
 FROZEN_ERROR = {
     "error_code": "ENTRY_FROZEN_IMMUTABLE",
     "detail": "Entry is frozen and cannot be modified",
@@ -85,19 +106,6 @@ SEED_QUESTIONS: list[tuple[str, str]] = [
     ("Quel objectif te motive pour demain ?", "projection"),
     ("Quelle émotion as-tu le plus ressentie aujourd'hui ?", "emotion"),
 ]
-
-
-@app.on_event("startup")
-def startup() -> None:
-    configure_json_logging()
-    settings.data_dir.mkdir(parents=True, exist_ok=True)
-    settings.audio_dir.mkdir(parents=True, exist_ok=True)
-    if not inspect(engine).has_table("entries"):
-        logger.warning("Database not initialized. Run: alembic upgrade head")
-        return
-
-    with Session(engine) as db:
-        _seed_admin_user(db)
 
 
 @app.exception_handler(HTTPException)


### PR DESCRIPTION
### Motivation
- Remove deprecated `@app.on_event("startup")` usage and eliminate related DeprecationWarning by using FastAPI's lifespan protocol.
- Preserve the exact startup behavior (JSON logging setup, data/audio directory creation, entries-table guard, and admin seeding in development) without changing business logic or API surface.

### Description
- Replaced the `@app.on_event("startup")` hook with an `@asynccontextmanager`-based `lifespan` function in `services/api/app/main.py` and wired it into `FastAPI(..., lifespan=lifespan)`.
- Added `from contextlib import asynccontextmanager` and moved the existing startup actions into the new `lifespan` context manager, keeping logic identical (directory creation, `inspect(engine).has_table("entries")` check, and `_seed_admin_user` call inside a `Session`).
- Removed the old `startup()` function so initialization is performed by the lifespan handler only, with no change to routes, schemas, or DB migrations.

### Testing
- Ran `ruff check .` which passed successfully.
- Ran `ruff format .` which completed and reformatted the touched file as needed.
- Ran the test suite with the same invocation used in CI: `PYTHONPATH=services/api pytest -q -m "not e2e"` which resulted in all tests passing (`40 passed, 3 deselected`).
- Noted that running `pytest -q -m "not e2e"` without `PYTHONPATH=services/api` in this environment fails due to import path resolution (`ModuleNotFoundError: No module named 'app'`), which is an environment invocation detail rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a285561f3c8330a603efee595c0a31)