### PR TITLE
Make entry audio optional; accept text-only entries and add migration/tests

### DIFF
--- a/services/api/alembic/versions/0008_make_audio_optional.py
+++ b/services/api/alembic/versions/0008_make_audio_optional.py
@@ -1,0 +1,55 @@
+"""make entry audio metadata optional
+
+Revision ID: 0008_make_audio_optional
+Revises: 0007_entry_assets
+Create Date: 2026-02-28
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0008_make_audio_optional"
+down_revision: Union[str, None] = "0007_entry_assets"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("entries") as batch_op:
+        batch_op.alter_column("audio_path", existing_type=sa.String(), nullable=True)
+        batch_op.alter_column("audio_mime", existing_type=sa.String(), nullable=True)
+        batch_op.alter_column("audio_size", existing_type=sa.Integer(), nullable=True)
+        batch_op.alter_column(
+            "audio_sha256", existing_type=sa.String(length=64), nullable=True
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    null_count = bind.execute(
+        sa.text(
+            """
+            SELECT COUNT(*)
+            FROM entries
+            WHERE audio_path IS NULL
+               OR audio_mime IS NULL
+               OR audio_size IS NULL
+               OR audio_sha256 IS NULL
+            """
+        )
+    ).scalar_one()
+    if null_count:
+        raise RuntimeError(
+            "Cannot downgrade 0008_make_audio_optional: entries contain rows without audio metadata."
+        )
+
+    with op.batch_alter_table("entries") as batch_op:
+        batch_op.alter_column(
+            "audio_sha256", existing_type=sa.String(length=64), nullable=False
+        )
+        batch_op.alter_column("audio_size", existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column("audio_mime", existing_type=sa.String(), nullable=False)
+        batch_op.alter_column("audio_path", existing_type=sa.String(), nullable=False)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -246,7 +246,8 @@ def get_question_today(
 async def create_entry(
     question_id: int = Form(...),
     text_content: str | None = Form(default=None),
-    audio_file: UploadFile = File(...),
+    text: str | None = Form(default=None),
+    audio_file: UploadFile | None = File(default=None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> Entry:
@@ -255,40 +256,69 @@ async def create_entry(
     if question is None:
         raise HTTPException(status_code=404, detail="Question not found")
 
-    content_type = audio_file.content_type or ""
-    if content_type not in ALLOWED_MIME_TYPES:
+    candidates = [text_content, text]
+    final_text = None
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        normalized = candidate.strip()
+        if normalized != "":
+            final_text = normalized
+            break
+
+    if audio_file is None and final_text is None:
         raise HTTPException(
-            status_code=422,
+            status_code=400,
             detail={
-                "code": "unsupported_mime",
-                "message": "Unsupported audio MIME type",
+                "code": "entry_empty",
+                "message": "Either text or audio_file is required",
             },
         )
-
-    _validate_text_content(text_content)
+    if final_text is not None:
+        _validate_text_content(final_text)
 
     entry_id = str(uuid.uuid4())
-    ext = ALLOWED_MIME_TYPES[content_type]
-    relative_path = Path("audio") / f"{entry_id}{ext}"
-    absolute_path = settings.data_dir / relative_path
-    upload_info = await stream_upload_to_disk(
-        upload=audio_file,
-        dst_path=absolute_path,
-        max_bytes=settings.max_upload_bytes,
-        expected_mime=content_type,
-        expected_ext=ext,
-    )
+    relative_path: Path | None = None
+    content_type: str | None = None
+    audio_size: int | None = None
+    audio_sha256: str | None = None
+    audio_duration_ms: int | None = None
+
+    if audio_file is not None:
+        content_type = audio_file.content_type or ""
+        if content_type not in ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "unsupported_mime",
+                    "message": "Unsupported audio MIME type",
+                },
+            )
+
+        ext = ALLOWED_MIME_TYPES[content_type]
+        relative_path = Path("audio") / f"{entry_id}{ext}"
+        absolute_path = settings.data_dir / relative_path
+        upload_info = await stream_upload_to_disk(
+            upload=audio_file,
+            dst_path=absolute_path,
+            max_bytes=settings.max_upload_bytes,
+            expected_mime=content_type,
+            expected_ext=ext,
+        )
+        audio_size = int(upload_info["size"])
+        audio_sha256 = str(upload_info["sha256"])
+        audio_duration_ms = upload_info["duration_ms"]
 
     entry = Entry(
         id=entry_id,
         user_id=current_user.id,
         question_id=question_id,
-        audio_path=str(relative_path),
+        audio_path=str(relative_path) if relative_path is not None else None,
         audio_mime=content_type,
-        audio_size=int(upload_info["size"]),
-        audio_sha256=str(upload_info["sha256"]),
-        audio_duration_ms=upload_info["duration_ms"],
-        text_content=text_content,
+        audio_size=audio_size,
+        audio_sha256=audio_sha256,
+        audio_duration_ms=audio_duration_ms,
+        text_content=final_text,
     )
     db.add(entry)
     db.commit()

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -50,10 +50,10 @@ class Entry(Base):
         ForeignKey("users.id"), index=True, nullable=False
     )
     question_id: Mapped[int] = mapped_column(ForeignKey("questions.id"), nullable=False)
-    audio_path: Mapped[str] = mapped_column(String, nullable=False)
-    audio_mime: Mapped[str] = mapped_column(String, nullable=False)
-    audio_size: Mapped[int] = mapped_column(Integer, nullable=False)
-    audio_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    audio_path: Mapped[str | None] = mapped_column(String, nullable=True)
+    audio_mime: Mapped[str | None] = mapped_column(String, nullable=True)
+    audio_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    audio_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     audio_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     text_content: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_frozen: Mapped[bool] = mapped_column(

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -37,8 +37,8 @@ class EntryOut(ORMBaseModel):
     id: str
     user_id: str
     question_id: int
-    audio_mime: str
-    audio_size: int
+    audio_mime: Optional[str]
+    audio_size: Optional[int]
     text_content: Optional[str] = None
     is_frozen: bool
     created_at: datetime

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -232,6 +232,120 @@ def test_create_entry_with_text_content_and_readback(tmp_path, monkeypatch):
     assert fetched.json()["text_content"] == "hello"
 
 
+def test_create_entry_text_only_ok(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text": "hello"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["text_content"] == "hello"
+    assert response.json()["audio_mime"] is None
+    assert response.json()["audio_size"] is None
+
+
+def test_create_entry_audio_only_ok(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audio_mime"] == "audio/mpeg"
+
+
+def test_create_entry_text_and_audio_ok(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text": "hello"},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["text_content"] == "hello"
+    assert response.json()["audio_mime"] == "audio/mpeg"
+    assert response.json()["audio_size"] == len(VALID_MP3_BYTES)
+
+
+def test_create_entry_rejects_empty(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id)},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "entry_empty",
+            "message": "Either text or audio_file is required",
+        }
+    }
+
+
+def test_create_entry_prefers_first_non_empty_text_field(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text_content": "", "text": "hello"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["text_content"] == "hello"
+
+
+def test_create_entry_does_not_store_empty_text(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text": "   "},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["text_content"] is None
+
+
 def test_text_content_length_validation(tmp_path, monkeypatch):
     monkeypatch.setenv("MAX_TEXT_CHARS", "5")
     client = _build_client(tmp_path, monkeypatch)


### PR DESCRIPTION
### Motivation
- Allow creating entries that contain text only or audio only by making audio metadata nullable in the DB and API. 
- Normalize incoming form fields so both legacy `text_content` and new `text` are supported and the first non-empty text is used. 

### Description
- Added Alembic migration `services/api/alembic/versions/0008_make_audio_optional.py` to make `entries` audio columns nullable and to prevent unsafe downgrades when null audio metadata exists. 
- Updated the `Entry` model to mark `audio_path`, `audio_mime`, `audio_size`, and `audio_sha256` as nullable. 
- Modified `create_entry` in `services/api/app/main.py` to accept optional `audio_file`, accept both `text_content` and `text` form fields, pick the first non-empty trimmed text, require at least text or audio (returns a `400` with code `entry_empty`), and only process audio upload when `audio_file` is present. 
- Updated `EntryOut` schema in `services/api/app/schemas.py` to reflect optional audio fields and extended `services/api/tests/test_entries.py` with tests covering text-only, audio-only, combined submissions, empty rejection, prefer-first-non-empty-text behavior, and trimming empty text. 

### Testing
- Ran the API unit tests in `services/api/tests/test_entries.py` with `pytest` and the updated test cases passed. 
- Verified the application-level behavior for `create_entry` with combinations of `text`/`text_content` and `audio_file` through the added tests which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2885410888330a906820901209910)