### PR TITLE
Add image asset support (upload, list, download) with validation and tests

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -19,18 +19,29 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, JSONResponse
-from sqlalchemy import inspect, select
+from sqlalchemy import func, inspect, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.db import engine, get_db
 from app.middleware.request_id import RequestIdMiddleware, configure_json_logging
-from app.models import Entry, Question, User
+from app.models import Entry, EntryAsset, Question, User
 from app.routes.auth import router as auth_router
 from app.routes.system import router as system_router
-from app.schemas import EntriesListResponse, EntryOut, EntryUpdateIn, QuestionOut
+from app.schemas import (
+    EntriesListResponse,
+    EntryAssetOut,
+    EntryOut,
+    EntryUpdateIn,
+    QuestionOut,
+)
 from app.security import get_current_user, hash_password
 from app.settings import settings
-from app.storage import ALLOWED_MIME_TYPES, stream_upload_to_disk
+from app.storage import (
+    ALLOWED_IMAGE_MIME_TYPES,
+    ALLOWED_MIME_TYPES,
+    stream_upload_to_disk,
+    validate_image_signature,
+)
 
 logger = logging.getLogger(__name__)
 api_v1_router = APIRouter(prefix="/api/v1")
@@ -41,6 +52,7 @@ async def lifespan(_: FastAPI):
     configure_json_logging()
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     settings.audio_dir.mkdir(parents=True, exist_ok=True)
+    settings.images_dir.mkdir(parents=True, exist_ok=True)
     if not inspect(engine).has_table("entries"):
         logger.warning("Database not initialized. Run: alembic upgrade head")
         yield
@@ -224,6 +236,49 @@ def _validate_text_content(text_content: str | None) -> None:
         )
 
 
+def _parse_image_dimensions(path: Path, mime: str) -> tuple[int | None, int | None]:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None, None
+
+    if (
+        mime == "image/png"
+        and len(data) >= 24
+        and data.startswith(b"\x89PNG\r\n\x1a\n")
+    ):
+        width = int.from_bytes(data[16:20], "big")
+        height = int.from_bytes(data[20:24], "big")
+        return width, height
+
+    if mime == "image/jpeg":
+        idx = 2
+        total = len(data)
+        while idx + 9 < total:
+            if data[idx] != 0xFF:
+                idx += 1
+                continue
+            marker = data[idx + 1]
+            idx += 2
+            while marker == 0xFF and idx < total:
+                marker = data[idx]
+                idx += 1
+            if marker in {0xD8, 0xD9} or 0xD0 <= marker <= 0xD7:
+                continue
+            if idx + 1 >= total:
+                break
+            seg_len = (data[idx] << 8) + data[idx + 1]
+            if seg_len < 2 or idx + seg_len > total:
+                break
+            if marker in {0xC0, 0xC2} and seg_len >= 7:
+                height = (data[idx + 3] << 8) + data[idx + 4]
+                width = (data[idx + 5] << 8) + data[idx + 6]
+                return width, height
+            idx += seg_len
+
+    return None, None
+
+
 @api_v1_router.get("/questions/today", response_model=QuestionOut)
 def get_question_today(
     _: User = Depends(get_current_user), db: Session = Depends(get_db)
@@ -390,6 +445,130 @@ def freeze_entry(
     return {"status": "frozen", "id": entry_id, "is_frozen": True}
 
 
+@api_v1_router.post("/entries/{entry_id}/assets", response_model=EntryAssetOut)
+async def upload_entry_asset(
+    entry_id: str,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> EntryAsset:
+    entry = _get_entry_or_404(db, entry_id)
+    _ensure_owner(entry, current_user)
+    _ensure_not_frozen(entry)
+
+    existing_assets_count = db.execute(
+        select(func.count())
+        .select_from(EntryAsset)
+        .where(
+            EntryAsset.entry_id == entry_id,
+            EntryAsset.asset_type == "image",
+        )
+    ).scalar_one()
+    if existing_assets_count >= settings.max_images_per_entry:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "too_many_assets",
+                "message": (
+                    "Entry reached MAX_IMAGES_PER_ENTRY "
+                    f"({settings.max_images_per_entry})"
+                ),
+            },
+        )
+
+    content_type = file.content_type or ""
+    if content_type not in ALLOWED_IMAGE_MIME_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "unsupported_image_mime",
+                "message": "Unsupported image MIME type",
+            },
+        )
+
+    asset_id = str(uuid.uuid4())
+    ext = ALLOWED_IMAGE_MIME_TYPES[content_type]
+    relative_path = Path("images") / entry_id / f"{asset_id}{ext}"
+    absolute_path = settings.data_dir / relative_path
+
+    upload_info = await stream_upload_to_disk(
+        upload=file,
+        dst_path=absolute_path,
+        max_bytes=settings.max_upload_image_bytes,
+        expected_mime=content_type,
+        expected_ext=ext,
+        signature_validator=validate_image_signature,
+        invalid_signature_error_code="invalid_image_signature",
+        invalid_signature_error_message="Image signature does not match MIME type",
+        payload_too_large_error_message="Image file exceeds upload size limit",
+    )
+
+    width, height = _parse_image_dimensions(absolute_path, content_type)
+
+    asset = EntryAsset(
+        id=asset_id,
+        entry_id=entry.id,
+        user_id=current_user.id,
+        asset_type="image",
+        path=str(relative_path),
+        mime=content_type,
+        size=int(upload_info["size"]),
+        sha256=str(upload_info["sha256"]),
+        width=width,
+        height=height,
+    )
+    db.add(asset)
+    db.commit()
+    db.refresh(asset)
+    return asset
+
+
+@api_v1_router.get("/entries/{entry_id}/assets", response_model=list[EntryAssetOut])
+def list_entry_assets(
+    entry_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[EntryAsset]:
+    entry = _get_entry_or_404(db, entry_id)
+    _ensure_owner(entry, current_user)
+    return (
+        db.execute(
+            select(EntryAsset)
+            .where(EntryAsset.entry_id == entry_id, EntryAsset.asset_type == "image")
+            .order_by(EntryAsset.created_at.asc())
+        )
+        .scalars()
+        .all()
+    )
+
+
+@api_v1_router.get("/assets/{asset_id}")
+def download_asset(
+    asset_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FileResponse:
+    asset = db.get(EntryAsset, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    if asset.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "forbidden", "message": "Not allowed"},
+        )
+
+    if asset.asset_type != "image":
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "asset_not_image", "message": "Asset is not an image"},
+        )
+
+    path = settings.data_dir / asset.path
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Asset file not found")
+    return FileResponse(path=path, media_type=asset.mime, filename=path.name)
+
+
 @api_v1_router.get("/entries/{entry_id}/audio")
 def get_entry_audio(
     entry_id: str,
@@ -398,6 +577,12 @@ def get_entry_audio(
 ) -> FileResponse:
     entry = _get_entry_or_404(db, entry_id)
     _ensure_owner(entry, current_user)
+    if entry.audio_path is None or entry.audio_mime is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "no_audio", "message": "Entry has no audio"},
+        )
+
     path = settings.data_dir / entry.audio_path
     if not path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found")

--- a/services/api/app/settings.py
+++ b/services/api/app/settings.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
     app_env: str = "development"
     data_dir: Path = Path("/app/data")
     max_upload_size_mb: int = 25
+    max_upload_image_mb: int = 8
+    max_images_per_entry: int = 8
     # Maximum allowed size for optional entry text content.
     max_text_chars: int = 10_000
 
@@ -49,6 +51,14 @@ class Settings(BaseSettings):
     @property
     def audio_dir(self) -> Path:
         return self.data_dir / "audio"
+
+    @property
+    def images_dir(self) -> Path:
+        return self.data_dir / "images"
+
+    @property
+    def max_upload_image_bytes(self) -> int:
+        return self.max_upload_image_mb * 1024 * 1024
 
     @field_validator("allowed_origins", "allowed_hosts", mode="before")
     @classmethod

--- a/services/api/app/storage.py
+++ b/services/api/app/storage.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 import wave
 
 from fastapi import HTTPException, UploadFile
@@ -20,6 +20,12 @@ ALLOWED_MIME_TYPES = {
     "audio/3gpp2": ".3g2",
     "audio/webm": ".webm",
     "audio/aiff": ".aiff",
+}
+
+ALLOWED_IMAGE_MIME_TYPES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
 }
 
 ALLOWED_EXTENSIONS_BY_MIME = {
@@ -85,6 +91,18 @@ def has_valid_signature(header: bytes, mime_type: str) -> bool:
     return False
 
 
+def validate_image_signature(header: bytes, mime_type: str) -> bool:
+    if mime_type == "image/jpeg":
+        return len(header) >= 3 and header.startswith(b"\xff\xd8\xff")
+    if mime_type == "image/png":
+        return len(header) >= 8 and header.startswith(b"\x89PNG\r\n\x1a\n")
+    if mime_type == "image/webp":
+        return (
+            len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WEBP"
+        )
+    return False
+
+
 def _try_get_wav_duration_ms(path: Path) -> Optional[int]:
     try:
         with wave.open(str(path), "rb") as wav_file:
@@ -103,6 +121,10 @@ async def stream_upload_to_disk(
     max_bytes: int,
     expected_mime: str,
     expected_ext: str,
+    signature_validator: Callable[[bytes, str], bool] | None = None,
+    invalid_signature_error_code: str = "invalid_signature",
+    invalid_signature_error_message: str = "Audio signature does not match MIME type",
+    payload_too_large_error_message: str = "Audio file exceeds upload size limit",
 ) -> dict[str, Optional[int] | str]:
     suffix = Path(upload.filename or "").suffix.lower()
     allowed = ALLOWED_EXTENSIONS_BY_MIME.get(expected_mime, {expected_ext.lower()})
@@ -116,12 +138,13 @@ async def stream_upload_to_disk(
         )
 
     header = await upload.read(512)
-    if not header or not has_valid_signature(header, expected_mime):
+    signature_check = signature_validator or has_valid_signature
+    if not header or not signature_check(header, expected_mime):
         raise HTTPException(
             status_code=422,
             detail={
-                "code": "invalid_signature",
-                "message": "Audio signature does not match MIME type",
+                "code": invalid_signature_error_code,
+                "message": invalid_signature_error_message,
             },
         )
 
@@ -138,7 +161,7 @@ async def stream_upload_to_disk(
                     status_code=413,
                     detail={
                         "code": "payload_too_large",
-                        "message": "Audio file exceeds upload size limit",
+                        "message": payload_too_large_error_message,
                     },
                 )
             digest.update(header)
@@ -155,7 +178,7 @@ async def stream_upload_to_disk(
                         status_code=413,
                         detail={
                             "code": "payload_too_large",
-                            "message": "Audio file exceeds upload size limit",
+                            "message": payload_too_large_error_message,
                         },
                     )
                 digest.update(chunk)

--- a/services/api/tests/test_assets_images.py
+++ b/services/api/tests/test_assets_images.py
@@ -1,0 +1,279 @@
+from io import BytesIO
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api/v1"
+PNG_1X1_BYTES = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR"
+    b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00"
+    b"\x90wS\xde"
+    b"\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01"
+    b"\xf6\x178U"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _build_client(tmp_path, monkeypatch, *, max_images_per_entry: int = 8):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-access-secret")
+    monkeypatch.setenv("JWT_REFRESH_SECRET_KEY", "test-refresh-secret")
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("MAX_IMAGES_PER_ENTRY", str(max_images_per_entry))
+
+    import app.db
+    import app.main
+    import app.settings
+
+    app.settings.settings = app.settings.Settings()
+    app.db.settings = app.settings.settings
+    app.main.settings = app.settings.settings
+
+    app.db.engine.dispose()
+    app.db.engine = app.db.create_engine(
+        f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    app.db.SessionLocal.configure(bind=app.db.engine)
+    app.main.engine = app.db.engine
+
+    api_dir = Path(__file__).resolve().parents[1]
+    alembic_cfg = Config(str(api_dir / "alembic.ini"))
+    alembic_cfg.set_main_option("script_location", str(api_dir / "alembic"))
+    alembic_cfg.set_main_option(
+        "sqlalchemy.url", f"sqlite:///{app.settings.settings.data_dir / 'echo.db'}"
+    )
+    command.upgrade(alembic_cfg, "head")
+
+    from app.models import User
+    from app.security import hash_password
+
+    with app.db.SessionLocal() as db:
+        db.add(
+            User(
+                email="user_a@example.com",
+                password_hash=hash_password("password-a"),
+                is_active=True,
+            )
+        )
+        db.add(
+            User(
+                email="user_b@example.com",
+                password_hash=hash_password("password-b"),
+                is_active=True,
+            )
+        )
+        db.commit()
+
+    return TestClient(app.main.app)
+
+
+def _auth_headers(client: TestClient, email: str, password: str) -> dict[str, str]:
+    response = client.post(
+        f"{API_PREFIX}/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_text_entry(client: TestClient, headers: dict[str, str]) -> str:
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+    response = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text_content": "hello"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    return str(response.json()["id"])
+
+
+def test_image_asset_upload_list_and_download(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+    entry_id = _create_text_entry(client, headers)
+
+    upload = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers,
+    )
+    assert upload.status_code == 200
+    uploaded = upload.json()
+    assert uploaded["asset_type"] == "image"
+    assert uploaded["mime"] == "image/png"
+    assert uploaded["size"] == len(PNG_1X1_BYTES)
+    assert uploaded["sha256"]
+    assert uploaded["width"] == 1
+    assert uploaded["height"] == 1
+
+    disk_path = tmp_path / uploaded["path"]
+    assert disk_path.exists()
+
+    listed = client.get(f"{API_PREFIX}/entries/{entry_id}/assets", headers=headers)
+    assert listed.status_code == 200
+    assets = listed.json()
+    assert len(assets) == 1
+    assert assets[0]["id"] == uploaded["id"]
+
+    downloaded = client.get(f"{API_PREFIX}/assets/{uploaded['id']}", headers=headers)
+    assert downloaded.status_code == 200
+    assert downloaded.headers["content-type"] == "image/png"
+    assert downloaded.content == PNG_1X1_BYTES
+
+
+def test_image_asset_validation_rejects_bad_mime_and_signature(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+    entry_id = _create_text_entry(client, headers)
+
+    bad_mime = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.txt", BytesIO(PNG_1X1_BYTES), "text/plain")},
+        headers=headers,
+    )
+    assert bad_mime.status_code == 422
+    assert bad_mime.json() == {
+        "error": {
+            "code": "unsupported_image_mime",
+            "message": "Unsupported image MIME type",
+        }
+    }
+
+    bad_signature = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(b"not-a-png"), "image/png")},
+        headers=headers,
+    )
+    assert bad_signature.status_code == 422
+    assert bad_signature.json() == {
+        "error": {
+            "code": "invalid_image_signature",
+            "message": "Image signature does not match MIME type",
+        }
+    }
+
+
+def test_image_asset_acl_and_freeze(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers_a = _auth_headers(client, "user_a@example.com", "password-a")
+    headers_b = _auth_headers(client, "user_b@example.com", "password-b")
+    entry_id = _create_text_entry(client, headers_a)
+
+    upload = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers_a,
+    )
+    assert upload.status_code == 200
+    asset_id = upload.json()["id"]
+
+    forbidden_upload = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers_b,
+    )
+    assert forbidden_upload.status_code == 403
+
+    forbidden_list = client.get(
+        f"{API_PREFIX}/entries/{entry_id}/assets", headers=headers_b
+    )
+    assert forbidden_list.status_code == 403
+
+    forbidden_download = client.get(
+        f"{API_PREFIX}/assets/{asset_id}", headers=headers_b
+    )
+    assert forbidden_download.status_code == 403
+
+    freeze = client.post(f"{API_PREFIX}/entries/{entry_id}/freeze", headers=headers_a)
+    assert freeze.status_code == 200
+
+    frozen_upload = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers_a,
+    )
+    assert frozen_upload.status_code == 409
+    assert frozen_upload.json() == {
+        "error_code": "ENTRY_FROZEN_IMMUTABLE",
+        "detail": "Entry is frozen and cannot be modified",
+    }
+
+
+def test_image_asset_max_per_entry_limit(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch, max_images_per_entry=1)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+    entry_id = _create_text_entry(client, headers)
+
+    first = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers,
+    )
+    assert second.status_code == 422
+    assert second.json() == {
+        "error": {
+            "code": "too_many_assets",
+            "message": "Entry reached MAX_IMAGES_PER_ENTRY (1)",
+        }
+    }
+
+
+def test_get_entry_audio_returns_no_audio_for_text_only_entry(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+    entry_id = _create_text_entry(client, headers)
+
+    response = client.get(f"{API_PREFIX}/entries/{entry_id}/audio", headers=headers)
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "no_audio",
+            "message": "Entry has no audio",
+        }
+    }
+
+
+def test_download_asset_rejects_non_image_asset_type(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+    entry_id = _create_text_entry(client, headers)
+
+    upload = client.post(
+        f"{API_PREFIX}/entries/{entry_id}/assets",
+        files={"file": ("pixel.png", BytesIO(PNG_1X1_BYTES), "image/png")},
+        headers=headers,
+    )
+    assert upload.status_code == 200
+    asset_id = upload.json()["id"]
+
+    import app.db
+    from app.models import EntryAsset
+
+    with app.db.SessionLocal() as db:
+        asset = db.get(EntryAsset, asset_id)
+        assert asset is not None
+        asset.asset_type = "document"
+        db.commit()
+
+    response = client.get(f"{API_PREFIX}/assets/{asset_id}", headers=headers)
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "asset_not_image",
+            "message": "Asset is not an image",
+        }
+    }


### PR DESCRIPTION
### Motivation

- Add first-class support for image attachments on entries with server-side validation, size limits, and ownership checks.
- Surface clear errors for missing audio on text-only entries and protect frozen entries from modification.

### Description

- Add image-related settings `max_upload_image_mb`, `max_images_per_entry`, `images_dir`, and `max_upload_image_bytes` to `settings.py` and ensure the images directory is created during application `lifespan` initialization. 
- Implement image handling in `main.py`: import `EntryAsset`, add `upload_entry_asset`, `list_entry_assets`, and `download_asset` endpoints, enforce ownership and frozen checks, enforce per-entry image count (`max_images_per_entry`), and parse image dimensions via `_parse_image_dimensions`. 
- Extend `storage.py` with `ALLOWED_IMAGE_MIME_TYPES`, a `validate_image_signature` function for image signatures, and make `stream_upload_to_disk` accept a pluggable `signature_validator` and customizable error messages; reuse it for image uploads with size and signature checks. 
- Improve `get_entry_audio` to return a structured `404` when an entry has no audio. 
- Add API schemas usage for `EntryAssetOut` and wire saved asset metadata (`width`, `height`, `size`, `sha256`, `path`, `mime`) into the DB record returned by the upload endpoint.

### Testing

- Added `services/api/tests/test_assets_images.py` covering image upload/list/download flow, signature and MIME validation, ACL and freeze behavior, per-entry image limit, and audio-not-found behavior. 
- Ran the new test file with `pytest services/api/tests/test_assets_images.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28b4b856c83308013848c0e6793c7)