### PR TITLE
Expose asset download and entry audio URLs in API responses

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -13,6 +13,7 @@ from fastapi import (
     Form,
     HTTPException,
     Query,
+    Request,
     UploadFile,
 )
 from fastapi.exceptions import RequestValidationError
@@ -279,6 +280,37 @@ def _parse_image_dimensions(path: Path, mime: str) -> tuple[int | None, int | No
     return None, None
 
 
+def _asset_download_url(request: Request, asset_id: str) -> str:
+    return str(request.url_for("download_asset", asset_id=asset_id))
+
+
+def _entry_audio_url(request: Request, entry_id: str) -> str:
+    return str(request.url_for("get_entry_audio", entry_id=entry_id))
+
+
+def _serialize_asset(request: Request, asset: EntryAsset) -> EntryAssetOut:
+    serialized = EntryAssetOut.model_validate(asset, from_attributes=True)
+    return serialized.model_copy(
+        update={"download_url": _asset_download_url(request, asset.id)}
+    )
+
+
+def _serialize_entry(request: Request, entry: Entry) -> EntryOut:
+    serialized = EntryOut.model_validate(entry, from_attributes=True)
+    assets = list(entry.assets or [])
+    assets = [asset for asset in assets if asset.asset_type == "image"]
+    return serialized.model_copy(
+        update={
+            "assets": [_serialize_asset(request, asset) for asset in assets],
+            "audio_url": (
+                _entry_audio_url(request, entry.id)
+                if entry.audio_path is not None and entry.audio_mime is not None
+                else None
+            ),
+        }
+    )
+
+
 @api_v1_router.get("/questions/today", response_model=QuestionOut)
 def get_question_today(
     _: User = Depends(get_current_user), db: Session = Depends(get_db)
@@ -299,13 +331,14 @@ def get_question_today(
 
 @api_v1_router.post("/entries", response_model=EntryOut)
 async def create_entry(
+    request: Request,
     question_id: int = Form(...),
     text_content: str | None = Form(default=None),
     text: str | None = Form(default=None),
     audio_file: UploadFile | None = File(default=None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Entry:
+) -> EntryOut:
     _ensure_questions_seeded(db)
     question = db.get(Question, question_id)
     if question is None:
@@ -378,11 +411,15 @@ async def create_entry(
     db.add(entry)
     db.commit()
     db.refresh(entry)
-    return entry
+    entry = db.execute(
+        select(Entry).options(selectinload(Entry.assets)).where(Entry.id == entry_id)
+    ).scalar_one()
+    return _serialize_entry(request, entry)
 
 
 @api_v1_router.get("/entries", response_model=EntriesListResponse)
 def list_entries(
+    request: Request,
     limit: int = Query(
         default=50, ge=1, description="Page size. Values above 200 are clamped to 200."
     ),
@@ -414,19 +451,23 @@ def list_entries(
     )
     next_offset = offset + len(entries) if len(entries) == clamped_limit else None
     return EntriesListResponse(
-        items=entries, next_offset=next_offset, limit=clamped_limit, offset=offset
+        items=[_serialize_entry(request, entry) for entry in entries],
+        next_offset=next_offset,
+        limit=clamped_limit,
+        offset=offset,
     )
 
 
 @api_v1_router.get("/entries/{entry_id}", response_model=EntryOut)
 def get_entry(
+    request: Request,
     entry_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Entry:
+) -> EntryOut:
     entry = _get_entry_or_404(db, entry_id, load_assets=True)
     _ensure_owner(entry, current_user)
-    return entry
+    return _serialize_entry(request, entry)
 
 
 @api_v1_router.post("/entries/{entry_id}/freeze")
@@ -447,11 +488,12 @@ def freeze_entry(
 
 @api_v1_router.post("/entries/{entry_id}/assets", response_model=EntryAssetOut)
 async def upload_entry_asset(
+    request: Request,
     entry_id: str,
     file: UploadFile = File(...),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> EntryAsset:
+) -> EntryAssetOut:
     entry = _get_entry_or_404(db, entry_id)
     _ensure_owner(entry, current_user)
     _ensure_not_frozen(entry)
@@ -520,18 +562,19 @@ async def upload_entry_asset(
     db.add(asset)
     db.commit()
     db.refresh(asset)
-    return asset
+    return _serialize_asset(request, asset)
 
 
 @api_v1_router.get("/entries/{entry_id}/assets", response_model=list[EntryAssetOut])
 def list_entry_assets(
+    request: Request,
     entry_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[EntryAsset]:
+) -> list[EntryAssetOut]:
     entry = _get_entry_or_404(db, entry_id)
     _ensure_owner(entry, current_user)
-    return (
+    assets = (
         db.execute(
             select(EntryAsset)
             .where(EntryAsset.entry_id == entry_id, EntryAsset.asset_type == "image")
@@ -540,9 +583,10 @@ def list_entry_assets(
         .scalars()
         .all()
     )
+    return [_serialize_asset(request, asset) for asset in assets]
 
 
-@api_v1_router.get("/assets/{asset_id}")
+@api_v1_router.get("/assets/{asset_id}", name="download_asset")
 def download_asset(
     asset_id: str,
     current_user: User = Depends(get_current_user),
@@ -569,7 +613,7 @@ def download_asset(
     return FileResponse(path=path, media_type=asset.mime, filename=path.name)
 
 
-@api_v1_router.get("/entries/{entry_id}/audio")
+@api_v1_router.get("/entries/{entry_id}/audio", name="get_entry_audio")
 def get_entry_audio(
     entry_id: str,
     current_user: User = Depends(get_current_user),

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -29,6 +29,7 @@ class EntryAssetOut(ORMBaseModel):
     size: int
     sha256: str
     created_at: datetime
+    download_url: str = ""
     width: Optional[int] = None
     height: Optional[int] = None
 
@@ -40,6 +41,7 @@ class EntryOut(ORMBaseModel):
     audio_mime: Optional[str]
     audio_size: Optional[int]
     text_content: Optional[str] = None
+    audio_url: Optional[str] = None
     is_frozen: bool
     created_at: datetime
     assets: list[EntryAssetOut] = Field(default_factory=list)

--- a/services/api/tests/test_assets_images.py
+++ b/services/api/tests/test_assets_images.py
@@ -6,6 +6,7 @@ from alembic.config import Config
 from fastapi.testclient import TestClient
 
 API_PREFIX = "/api/v1"
+VALID_MP3_BYTES = b"ID3\x04\x00\x00\x00\x00\x00\x00payload"
 PNG_1X1_BYTES = (
     b"\x89PNG\r\n\x1a\n"
     b"\x00\x00\x00\rIHDR"
@@ -112,6 +113,7 @@ def test_image_asset_upload_list_and_download(tmp_path, monkeypatch):
     assert uploaded["sha256"]
     assert uploaded["width"] == 1
     assert uploaded["height"] == 1
+    assert uploaded["download_url"].endswith(f"{API_PREFIX}/assets/{uploaded['id']}")
 
     disk_path = tmp_path / uploaded["path"]
     assert disk_path.exists()
@@ -121,6 +123,7 @@ def test_image_asset_upload_list_and_download(tmp_path, monkeypatch):
     assets = listed.json()
     assert len(assets) == 1
     assert assets[0]["id"] == uploaded["id"]
+    assert assets[0]["download_url"].endswith(f"{API_PREFIX}/assets/{uploaded['id']}")
 
     downloaded = client.get(f"{API_PREFIX}/assets/{uploaded['id']}", headers=headers)
     assert downloaded.status_code == 200
@@ -230,6 +233,47 @@ def test_image_asset_max_per_entry_limit(tmp_path, monkeypatch):
             "message": "Entry reached MAX_IMAGES_PER_ENTRY (1)",
         }
     }
+
+
+def test_get_entry_includes_audio_url_when_audio_is_present(tmp_path, monkeypatch):
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client, "user_a@example.com", "password-a")
+
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    text_only = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text_content": "hello"},
+        headers=headers,
+    )
+    assert text_only.status_code == 200
+    text_only_id = text_only.json()["id"]
+
+    text_only_entry = client.get(
+        f"{API_PREFIX}/entries/{text_only_id}", headers=headers
+    )
+    assert text_only_entry.status_code == 200
+    assert text_only_entry.json()["audio_url"] is None
+
+    with_audio = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text_content": "with audio"},
+        files={"audio_file": ("voice.mp3", BytesIO(VALID_MP3_BYTES), "audio/mpeg")},
+        headers=headers,
+    )
+    assert with_audio.status_code == 200
+    with_audio_id = with_audio.json()["id"]
+
+    entry_with_audio = client.get(
+        f"{API_PREFIX}/entries/{with_audio_id}", headers=headers
+    )
+    assert entry_with_audio.status_code == 200
+    assert entry_with_audio.json()["audio_url"] is not None
+    assert entry_with_audio.json()["audio_url"].endswith(
+        f"{API_PREFIX}/entries/{with_audio_id}/audio"
+    )
 
 
 def test_get_entry_audio_returns_no_audio_for_text_only_entry(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation

- Provide clients with direct URLs for downloading entry assets and streaming entry audio instead of requiring them to construct paths manually.
- Ensure API responses use serialized output models (`EntryOut`/`EntryAssetOut`) that include these URLs and filter assets to image type.

### Description

- Added helper functions `._asset_download_url`, `._entry_audio_url`, `._serialize_asset`, and `._serialize_entry` to build URL fields and convert ORM instances to response models using the request context.
- Updated endpoints to accept `Request` and return serialized `EntryOut`/`EntryAssetOut` objects for `POST /entries`, `GET /entries`, `GET /entries/{entry_id}`, `POST /entries/{entry_id}/assets`, and `GET /entries/{entry_id}/assets`.
- Named routes `download_asset` and `get_entry_audio` and used `request.url_for` to generate `download_url` on `EntryAssetOut` and `audio_url` on `EntryOut`, and filtered entry assets to only include images.
- Extended schemas to include `download_url` on `EntryAssetOut` and `audio_url` on `EntryOut` and added small test fixture `VALID_MP3_BYTES` to exercise audio behavior.
- Updated tests in `services/api/tests/test_assets_images.py` to assert presence and correctness of `download_url` and `audio_url` values.

### Testing

- Ran the updated test file with `pytest services/api/tests/test_assets_images.py` which includes `test_image_asset_upload_list_and_download` and `test_get_entry_includes_audio_url_when_audio_is_present`, and they passed.
- Ran the API test suite with `pytest services/api` and observed no failures in the modified areas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a290ba39848330a76d206af8c330b9)