### PR TITLE
fix(api): delete_entry no longer errors for entries without audio (#65)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -742,10 +742,11 @@ def delete_entry(
     _ensure_owner(entry, current_user)
     _ensure_not_frozen(entry)
 
-    path = settings.data_dir / entry.audio_path
+    if entry.audio_path is not None:
+        path = settings.data_dir / entry.audio_path
+        path.unlink(missing_ok=True)
     db.delete(entry)
     db.commit()
-    path.unlink(missing_ok=True)
     return {"status": "deleted", "id": entry_id}
 
 

--- a/services/api/tests/test_entries.py
+++ b/services/api/tests/test_entries.py
@@ -251,6 +251,32 @@ def test_create_entry_text_only_ok(tmp_path, monkeypatch):
     assert response.json()["audio_size"] is None
 
 
+def test_delete_entry_without_audio(tmp_path, monkeypatch):
+    """delete_entry succeeds for entries that have no audio (text-only)."""
+    client = _build_client(tmp_path, monkeypatch)
+    headers = _auth_headers(client)
+    question_id = client.get(f"{API_PREFIX}/questions/today", headers=headers).json()[
+        "id"
+    ]
+
+    created = client.post(
+        f"{API_PREFIX}/entries",
+        data={"question_id": str(question_id), "text": "hello"},
+        headers=headers,
+    )
+    assert created.status_code == 200
+    entry_id = created.json()["id"]
+    assert created.json()["audio_mime"] is None
+
+    deleted = client.delete(f"{API_PREFIX}/entries/{entry_id}", headers=headers)
+    assert deleted.status_code == 200
+    assert deleted.json() == {"status": "deleted", "id": entry_id}
+
+    listed = client.get(f"{API_PREFIX}/entries", headers=headers)
+    assert listed.status_code == 200
+    assert listed.json()["items"] == []
+
+
 def test_create_entry_audio_only_ok(tmp_path, monkeypatch):
     client = _build_client(tmp_path, monkeypatch)
     headers = _auth_headers(client)


### PR DESCRIPTION
Only build path and unlink when entry.audio_path is set. Add test_delete_entry_without_audio for text-only entries.

Made-with: Cursor