### PR TITLE
fix(web): unifier la variable d'env de l'URL API (fix #79)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ APP_ENV=development
 # Shared data directory mounted in containers
 DATA_DIR=./data
 
-# Web configuration
+# API: hosts allowed by TrustedHost (add "api" for Docker so the web container can call the API)
+ALLOWED_HOSTS=localhost,127.0.0.1,testserver,api
+
+# Web: base URL of the API (used by Streamlit). In Docker, set to http://api:8000
 API_BASE_URL=http://api:8000

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Exemple dans `.env.example`:
 
 - `APP_ENV`: environnement applicatif (`development` par défaut)
 - `DATA_DIR`: dossier de données local (`./data`)
-- `ECHO_API_URL`: URL de l'API consommée par Streamlit (fallback: `http://localhost:8000`)
+- `API_BASE_URL`: URL de l'API consommée par Streamlit (Docker: `http://api:8000`). En local, on peut aussi utiliser `ECHO_API_URL` (fallback: `http://localhost:8000`)
 - `ALLOWED_ORIGINS`: liste CSV des origines CORS autorisées (défaut dev: `http://localhost:3000,http://localhost:8501,http://localhost:8000`)
 - `ALLOWED_HOSTS`: liste CSV des hosts HTTP autorisés (`localhost,127.0.0.1,testserver` par défaut)
 - `ENABLE_HSTS`: active l'en-tête `Strict-Transport-Security` (`false` par défaut)

--- a/apps/web/api_client.py
+++ b/apps/web/api_client.py
@@ -5,7 +5,10 @@ from typing import Any
 
 import requests
 
-API_BASE_URL = os.getenv("ECHO_API_URL", "http://localhost:8000").rstrip("/")
+# Prefer API_BASE_URL (Docker Compose); fallback to ECHO_API_URL for local dev
+API_BASE_URL = (
+    os.getenv("API_BASE_URL") or os.getenv("ECHO_API_URL") or "http://localhost:8000"
+).rstrip("/")
 API_BASE_PATH = "/api/v1"
 TIMEOUT_SECONDS = 20
 

--- a/apps/web/app.py
+++ b/apps/web/app.py
@@ -88,7 +88,7 @@ with st.sidebar:
             fetch_protected_bytes.clear()
             st.rerun()
 
-    st.caption(f"ECHO_API_URL: {API_BASE_URL}")
+    st.caption(f"URL API: {API_BASE_URL}")
 
 if not st.session_state.access_token:
     st.info("Veuillez vous connecter")


### PR DESCRIPTION
api_client: lire API_BASE_URL puis ECHO_API_URL (Docker Compose compatible)

app: libellé sidebar URL API

.env.example: documenter API_BASE_URL et ajouter ALLOWED_HOSTS avec api pour Docker

README: documenter API_BASE_URL et fallback ECHO_API_URL
Made-with: Cursor