### PR TITLE
fix: upload d'images (accepter image/jpg et extensions .jpeg)

### DIFF
--- a/apps/web/api_client.py
+++ b/apps/web/api_client.py
@@ -13,6 +13,18 @@ API_BASE_PATH = "/api/v1"
 TIMEOUT_SECONDS = 20
 
 
+def _mime_from_image_filename(name: str) -> str:
+    """Fallback MIME when UploadedFile.type is missing (e.g. Streamlit)."""
+    lower = name.lower()
+    if lower.endswith((".jpg", ".jpeg")):
+        return "image/jpeg"
+    if lower.endswith(".png"):
+        return "image/png"
+    if lower.endswith(".webp"):
+        return "image/webp"
+    return "image/jpeg"
+
+
 class ApiClientError(Exception):
     def __init__(
         self,
@@ -122,7 +134,10 @@ class APIClient:
         return payload if isinstance(payload, dict) else {}
 
     def upload_image(self, entry_id: str, image_file: Any) -> dict[str, Any]:
-        files = {"file": (image_file.name, image_file.getvalue(), image_file.type)}
+        mime = getattr(image_file, "type", None) or _mime_from_image_filename(
+            getattr(image_file, "name", "") or ""
+        )
+        files = {"file": (image_file.name, image_file.getvalue(), mime)}
         response = requests.post(
             f"{API_BASE_URL}{API_BASE_PATH}/entries/{entry_id}/assets",
             files=files,

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -522,6 +522,11 @@ async def upload_entry_asset(
 
     content_type = file.content_type or ""
     if content_type not in ALLOWED_IMAGE_MIME_TYPES:
+        logger.warning(
+            "asset upload 422: unsupported_image_mime content_type=%r allowed=%s",
+            content_type,
+            list(ALLOWED_IMAGE_MIME_TYPES.keys()),
+        )
         raise HTTPException(
             status_code=422,
             detail={

--- a/services/api/app/storage.py
+++ b/services/api/app/storage.py
@@ -24,6 +24,7 @@ ALLOWED_MIME_TYPES = {
 
 ALLOWED_IMAGE_MIME_TYPES = {
     "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",  # alias often sent by browsers/Streamlit
     "image/png": ".png",
     "image/webp": ".webp",
 }
@@ -33,6 +34,10 @@ ALLOWED_EXTENSIONS_BY_MIME = {
     "audio/x-m4a": {".m4a", ".mp4"},
     "audio/ogg": {".ogg", ".oga"},
     "audio/aiff": {".aiff", ".aif"},
+    "image/jpeg": {".jpg", ".jpeg"},
+    "image/jpg": {".jpg", ".jpeg"},
+    "image/png": {".png"},
+    "image/webp": {".webp"},
 }
 
 WAV_MIME_TYPES = {"audio/wav", "audio/x-wav"}
@@ -92,7 +97,7 @@ def has_valid_signature(header: bytes, mime_type: str) -> bool:
 
 
 def validate_image_signature(header: bytes, mime_type: str) -> bool:
-    if mime_type == "image/jpeg":
+    if mime_type in ("image/jpeg", "image/jpg"):
         return len(header) >= 3 and header.startswith(b"\xff\xd8\xff")
     if mime_type == "image/png":
         return len(header) >= 8 and header.startswith(b"\x89PNG\r\n\x1a\n")


### PR DESCRIPTION
API: ajout image/jpg dans ALLOWED_IMAGE_MIME_TYPES et validate_image_signature.

API: extensions .jpg et .jpeg acceptées pour image/jpeg (ALLOWED_EXTENSIONS_BY_MIME).

API: log warning en cas de 422 unsupported_image_mime.

Web: fallback MIME depuis le nom de fichier si type absent (upload_image).
Made-with: Cursor