### PR TITLE
feat(web-static): module client API (base URL, fetch avec token, 401)…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DATA_DIR=./data
 # API: hosts allowed by TrustedHost (add "api" for Docker so the web container can call the API)
 ALLOWED_HOSTS=localhost,127.0.0.1,testserver,api
 
+# API: CORS origins (front qui appelle l'API). Inclure 127.0.0.1:8080 pour web-static en dev.
+# ALLOWED_ORIGINS=http://localhost:8501,http://localhost:8080,http://127.0.0.1:8080
+
 # API: JWT (obligatoire pour le login). En prod, utiliser des secrets forts et uniques.
 JWT_SECRET_KEY=dev-secret-change-in-production
 JWT_REFRESH_SECRET_KEY=dev-refresh-secret-change-in-production

--- a/apps/web-static/api.js
+++ b/apps/web-static/api.js
@@ -1,0 +1,124 @@
+/**
+ * Client API pour web-static : base URL, fetch avec token, gestion 401.
+ * Usage : inclure avant app.js ; utiliser window.echoApi ou les fonctions exposées.
+ */
+(function () {
+  "use strict";
+
+  const API_PATH = "/api/v1";
+  const STORAGE_KEY = "echo_access_token";
+  const DEFAULT_BASE = "http://localhost:8000";
+
+  function getApiBaseUrl() {
+    const meta = document.querySelector('meta[name="echo-api-base"]');
+    if (meta && meta.content && meta.content.trim()) {
+      return meta.content.trim().replace(/\/+$/, "");
+    }
+    if (typeof window.ECHO_API_BASE_URL === "string" && window.ECHO_API_BASE_URL.trim()) {
+      return window.ECHO_API_BASE_URL.trim().replace(/\/+$/, "");
+    }
+    return DEFAULT_BASE;
+  }
+
+  function getAccessToken() {
+    try {
+      return sessionStorage.getItem(STORAGE_KEY) || "";
+    } catch {
+      return "";
+    }
+  }
+
+  function setAccessToken(token) {
+    try {
+      if (token) sessionStorage.setItem(STORAGE_KEY, token);
+      else sessionStorage.removeItem(STORAGE_KEY);
+    } catch (_) {}
+  }
+
+  function clearAccessToken() {
+    setAccessToken("");
+  }
+
+  function buildUrl(path) {
+    if (path.startsWith("http")) return path;
+    const base = getApiBaseUrl();
+    const p = path.startsWith("/") ? path : API_PATH + "/" + path;
+    return base + (p.startsWith("/") ? p : "/" + p);
+  }
+
+  /**
+   * Effectue un fetch vers l'API avec la base URL et le token.
+   * En cas de 401 : appelle onUnauthorized (si fourni), supprime le token, puis redirige vers /login
+   * sauf si onUnauthorized retourne true (pour éviter la redirection).
+   *
+   * @param {string} path - Chemin (ex: "/api/v1/auth/login", "/api/v1/entries")
+   * @param {RequestInit & { onUnauthorized?: () => boolean | void }} options - Options fetch + onUnauthorized
+   * @returns {Promise<Response>}
+   */
+  async function apiFetch(path, options = {}) {
+    const { onUnauthorized, ...fetchOptions } = options;
+    const url = buildUrl(path.startsWith(API_PATH) ? path : API_PATH + (path.startsWith("/") ? path : "/" + path));
+    const token = getAccessToken();
+    const headers = new Headers(fetchOptions.headers || {});
+    if (token) headers.set("Authorization", "Bearer " + token);
+    if (!headers.has("Content-Type") && fetchOptions.body && typeof fetchOptions.body === "string") {
+      headers.set("Content-Type", "application/json");
+    }
+    const res = await fetch(url, { ...fetchOptions, headers });
+    if (res.status === 401) {
+      clearAccessToken();
+      if (typeof onUnauthorized === "function") {
+        const preventRedirect = onUnauthorized();
+        if (preventRedirect === true) return res;
+      }
+      window.location.href = "/login";
+      return res;
+    }
+    return res;
+  }
+
+  /**
+   * Raccourci GET JSON.
+   */
+  async function apiGet(path, options = {}) {
+    const res = await apiFetch(path, { ...options, method: "GET" });
+    if (!res.ok) throw new ApiClientError(res.status, await res.text());
+    const ct = res.headers.get("Content-Type") || "";
+    if (ct.includes("application/json")) return res.json();
+    return res.text();
+  }
+
+  /**
+   * Raccourci POST JSON.
+   */
+  async function apiPost(path, body, options = {}) {
+    const res = await apiFetch(path, {
+      ...options,
+      method: "POST",
+      body: typeof body === "string" ? body : JSON.stringify(body || {}),
+    });
+    if (!res.ok) throw new ApiClientError(res.status, await res.text());
+    const ct = res.headers.get("Content-Type") || "";
+    if (ct.includes("application/json")) return res.json();
+    return res.text();
+  }
+
+  function ApiClientError(statusCode, message) {
+    this.name = "ApiClientError";
+    this.statusCode = statusCode;
+    this.message = message || "API error " + statusCode;
+  }
+  ApiClientError.prototype = Object.create(Error.prototype);
+
+  window.echoApi = {
+    getApiBaseUrl,
+    getAccessToken,
+    setAccessToken,
+    clearAccessToken,
+    apiFetch,
+    apiGet,
+    apiPost,
+    ApiClientError,
+    API_PATH,
+  };
+})();

--- a/apps/web-static/index.html
+++ b/apps/web-static/index.html
@@ -9,6 +9,8 @@
       name="description"
       content="echo — Timeline personnelle pour écrire, enregistrer et conserver des souvenirs."
     />
+    <!-- Optionnel : base URL de l'API (sinon window.ECHO_API_BASE_URL ou http://localhost:8000) -->
+    <meta name="echo-api-base" content="http://localhost:8000" />
 
     <title>echo — Accueil</title>
 
@@ -161,6 +163,7 @@
       </main>
     </div>
 
+    <script src="./api.js" defer></script>
     <script src="./app.js" defer></script>
   </body>
 </html>

--- a/services/api/app/settings.py
+++ b/services/api/app/settings.py
@@ -29,6 +29,8 @@ class Settings(BaseSettings):
         "http://localhost:3000",
         "http://localhost:8501",
         "http://localhost:8000",
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
     ]
     allowed_hosts: Annotated[list[str], NoDecode] = [
         "localhost",

--- a/services/api/tests/test_web_static_api_client.py
+++ b/services/api/tests/test_web_static_api_client.py
@@ -1,0 +1,51 @@
+"""
+Tests ciblés pour le module client API web-static (issue #90).
+Vérifie la présence et le contrat du module : base URL, fetch avec token, 401.
+"""
+from pathlib import Path
+
+import pytest
+
+# Repo root depuis services/api/tests -> api -> services -> repo
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WEB_STATIC_API_JS = REPO_ROOT / "apps" / "web-static" / "api.js"
+
+
+@pytest.fixture
+def api_js_content():
+    if not WEB_STATIC_API_JS.exists():
+        pytest.skip("apps/web-static/api.js non trouvé (hors repo echo?)")
+    return WEB_STATIC_API_JS.read_text(encoding="utf-8")
+
+
+def test_web_static_api_js_exists():
+    """Le module client API web-static doit exister."""
+    assert WEB_STATIC_API_JS.exists(), f"Fichier attendu: {WEB_STATIC_API_JS}"
+
+
+def test_web_static_api_client_exposes_base_url(api_js_content):
+    """Le module doit exposer une façon d'obtenir la base URL de l'API."""
+    assert "getApiBaseUrl" in api_js_content
+
+
+def test_web_static_api_client_exposes_token_handling(api_js_content):
+    """Le module doit exposer getter/setter pour le token."""
+    assert "getAccessToken" in api_js_content
+    assert "setAccessToken" in api_js_content
+
+
+def test_web_static_api_client_fetch_with_authorization(api_js_content):
+    """Le module doit faire des fetch avec Authorization Bearer."""
+    assert "apiFetch" in api_js_content
+    assert "Authorization" in api_js_content
+    assert "Bearer" in api_js_content
+
+
+def test_web_static_api_client_handles_401(api_js_content):
+    """Le module doit gérer explicitement le statut 401."""
+    assert "401" in api_js_content
+
+
+def test_web_static_api_client_exposes_echo_api_global(api_js_content):
+    """Le module doit attacher l'API au global window.echoApi."""
+    assert "echoApi" in api_js_content


### PR DESCRIPTION
… (#90)

- api.js : getApiBaseUrl (meta / ECHO_API_BASE_URL), get/setAccessToken, apiFetch avec Authorization Bearer, gestion 401 (onUnauthorized + redirect /login), apiGet/apiPost, ApiClientError

- index.html : meta echo-api-base, chargement api.js avant app.js

- tests : test_web_static_api_client.py (contrat du module)

- CORS : origines 8080 pour dev web-static ; .env.example documente ALLOWED_ORIGINS

Made-with: Cursor